### PR TITLE
Add Windows support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "pastel"
 version = "0.5.1"
 dependencies = [
@@ -175,6 +183,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "escargot 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -427,6 +436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
+"checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum predicates 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53e09015b0d3f5a0ec2d4428f7559bb7b3fff341b4e159fedd1d57fac8b939ff"
 "checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ exclude = ["doc/pastel.gif"]
 lazy_static = "1.3.0"
 rand = "0.7"
 atty = "0.2"
+output_vt100 = "0.1"
 
 # binary-only dependencies (see https://github.com/rust-lang/cargo/issues/1982)
 regex = "1"

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -38,6 +38,10 @@ fn run() -> Result<ExitCode> {
 
     let interactive_mode = atty::is(Stream::Stdout);
 
+    if interactive_mode {
+        output_vt100::init();
+    }
+
     let color_mode = match global_matches
         .value_of("color-mode")
         .expect("required argument")
@@ -55,6 +59,12 @@ fn run() -> Result<ExitCode> {
                     Some(value) => {
                         return Err(PastelError::UnknownColorMode(value.into()));
                     }
+                    #[cfg(windows)]
+                    None => {
+                        // Assume 24bit support on Windows
+                        Some(ansi::Mode::TrueColor)
+                    }
+                    #[cfg(not(windows))]
                     None => {
                         let env_colorterm = std::env::var("COLORTERM").ok();
                         match env_colorterm.as_ref().map(|s| s.as_str()) {


### PR DESCRIPTION
Partially address #45 (no support for `pick`).