### PR TITLE
Fix some color-bleed for non-pixel perfect fonts (fixes #72)

### DIFF
--- a/src/cli/commands/color_commands.rs
+++ b/src/cli/commands/color_commands.rs
@@ -1,5 +1,3 @@
-use std::io::Write;
-
 use crate::colorspace::get_mixing_function;
 use crate::commands::prelude::*;
 use crate::output::Output;
@@ -18,13 +16,13 @@ macro_rules! color_command {
         impl ColorCommand for $cmd_name {
             fn run(
                 &self,
-                out: &mut dyn Write,
+                out: &mut Output,
                 $matches: &ArgMatches,
                 $config: &Config,
                 $color: &Color,
             ) -> Result<()> {
                 let output = $body;
-                (Output::new(out)).show_color($config, &output)
+                out.show_color($config, &output)
             }
         }
     };

--- a/src/cli/commands/color_commands.rs
+++ b/src/cli/commands/color_commands.rs
@@ -1,6 +1,5 @@
 use crate::colorspace::get_mixing_function;
 use crate::commands::prelude::*;
-use crate::output::Output;
 
 use pastel::ColorblindnessType;
 use pastel::Fraction;

--- a/src/cli/commands/color_commands.rs
+++ b/src/cli/commands/color_commands.rs
@@ -1,13 +1,15 @@
+use std::io::Write;
+
 use crate::colorspace::get_mixing_function;
 use crate::commands::prelude::*;
+use crate::output::Output;
+
 use pastel::ColorblindnessType;
 use pastel::Fraction;
 
 fn clamp(lower: f64, upper: f64, x: f64) -> f64 {
     f64::max(f64::min(upper, x), lower)
 }
-
-use super::show::show_color;
 
 macro_rules! color_command {
     ($cmd_name:ident, $config:ident, $matches:ident, $color:ident, $body:block) => {
@@ -22,7 +24,7 @@ macro_rules! color_command {
                 $color: &Color,
             ) -> Result<()> {
                 let output = $body;
-                show_color(out, $config, &output)
+                (Output::new(out)).show_color($config, &output)
             }
         }
     };

--- a/src/cli/commands/colorcheck.rs
+++ b/src/cli/commands/colorcheck.rs
@@ -1,6 +1,5 @@
 use crate::commands::prelude::*;
 use crate::hdcanvas::Canvas;
-use crate::output::Output;
 
 use pastel::ansi::{Brush, Mode};
 

--- a/src/cli/commands/colorcheck.rs
+++ b/src/cli/commands/colorcheck.rs
@@ -1,11 +1,12 @@
 use crate::commands::prelude::*;
 use crate::hdcanvas::Canvas;
+use crate::output::Output;
 
 use pastel::ansi::{Brush, Mode};
 
 pub struct ColorCheckCommand;
 
-fn print_board(out: &mut dyn Write, config: &Config, mode: Mode) -> Result<()> {
+fn print_board(out: &mut Output, config: &Config, mode: Mode) -> Result<()> {
     // These colors have been chosen/computed such that the perceived color difference (CIE delta-E
     // 2000) to the closest ANSI 8-bit color is maximal.
     let c1 = Color::from_rgb(73, 39, 50);
@@ -38,19 +39,19 @@ fn print_board(out: &mut dyn Write, config: &Config, mode: Mode) -> Result<()> {
         &c3,
     );
 
-    canvas.print(out)
+    canvas.print(out.handle)
 }
 
 impl GenericCommand for ColorCheckCommand {
-    fn run(&self, out: &mut dyn Write, _: &ArgMatches, config: &Config) -> Result<()> {
-        writeln!(out, "\n8-bit mode:")?;
+    fn run(&self, out: &mut Output, _: &ArgMatches, config: &Config) -> Result<()> {
+        writeln!(out.handle, "\n8-bit mode:")?;
         print_board(out, config, Mode::Ansi8Bit)?;
 
-        writeln!(out, "24-bit mode:")?;
+        writeln!(out.handle, "24-bit mode:")?;
         print_board(out, config, Mode::TrueColor)?;
 
         writeln!(
-            out,
+            out.handle,
             "If your terminal emulator supports 24-bit colors, you should see three square color \
              panels in the lower row and the colors should look similar (but slightly different \
              from) the colors in the top row panels.\nThe panels in the lower row should look \

--- a/src/cli/commands/distinct.rs
+++ b/src/cli/commands/distinct.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::io::{self, Write};
 
 use crate::commands::prelude::*;
 
@@ -11,10 +11,10 @@ use pastel::random::{self, RandomizationStrategy};
 
 pub struct DistinctCommand;
 
-fn print_iteration(out: &mut Output, brush: &Brush, stats: &IterationStatistics) -> Result<()> {
+fn print_iteration(out: &mut dyn Write, brush: &Brush, stats: &IterationStatistics) -> Result<()> {
     let result = stats.distance_result;
     write!(
-        out.handle,
+        out,
         "[{:10.}] D_mean = {:<6.2}; D_min = {:<6.2}; T = {:.6} ",
         stats.iteration,
         result.mean_closest_distance,
@@ -26,7 +26,7 @@ fn print_iteration(out: &mut Output, brush: &Brush, stats: &IterationStatistics)
 }
 
 fn print_colors(
-    out: &mut Output,
+    out: &mut dyn Write,
     brush: &Brush,
     colors: &[Color],
     closest_pair: Option<(usize, usize)>,
@@ -45,14 +45,14 @@ fn print_colors(
         }
 
         write!(
-            out.handle,
+            out,
             "{} ",
             brush.paint(format!("{}", c.to_rgb_hex_string(false)), style)
         )?;
 
         ci += 1;
     }
-    writeln!(out.handle, "")?;
+    writeln!(out, "")?;
     Ok(())
 }
 
@@ -95,7 +95,7 @@ impl GenericCommand for DistinctCommand {
 
         let mut callback: Box<dyn FnMut(&IterationStatistics)> = if matches.is_present("verbose") {
             Box::new(|stats: &IterationStatistics| {
-                print_iteration(&mut Output::new(&mut stderr.lock()), &brush_stderr, stats).ok();
+                print_iteration(&mut stderr.lock(), &brush_stderr, stats).ok();
             })
         } else {
             Box::new(|_: &IterationStatistics| {})

--- a/src/cli/commands/distinct.rs
+++ b/src/cli/commands/distinct.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use crate::commands::prelude::*;
-use crate::commands::show::show_color;
+use crate::output::Output;
 
 use pastel::ansi::Stream;
 use pastel::distinct::{
@@ -59,6 +59,7 @@ fn print_colors(
 
 impl GenericCommand for DistinctCommand {
     fn run(&self, out: &mut dyn Write, matches: &ArgMatches, config: &Config) -> Result<()> {
+        let mut o = Output::new(out);
         let stderr = io::stderr();
         let brush_stderr = Brush::from_environment(Stream::Stderr);
 
@@ -119,7 +120,7 @@ impl GenericCommand for DistinctCommand {
             distinct::rearrange_sequence(&mut colors, distance_metric);
 
             for color in colors {
-                show_color(out, config, &color)?;
+                o.show_color(config, &color)?;
             }
         }
 

--- a/src/cli/commands/distinct.rs
+++ b/src/cli/commands/distinct.rs
@@ -1,7 +1,6 @@
 use std::io;
 
 use crate::commands::prelude::*;
-use crate::output::Output;
 
 use pastel::ansi::Stream;
 use pastel::distinct::{

--- a/src/cli/commands/format.rs
+++ b/src/cli/commands/format.rs
@@ -1,5 +1,4 @@
 use crate::commands::prelude::*;
-use crate::output::Output;
 use crate::utility::similar_colors;
 
 use pastel::ansi::Mode;

--- a/src/cli/commands/format.rs
+++ b/src/cli/commands/format.rs
@@ -1,4 +1,5 @@
 use crate::commands::prelude::*;
+use crate::output::Output;
 use crate::utility::similar_colors;
 
 use pastel::ansi::Mode;
@@ -9,7 +10,7 @@ pub struct FormatCommand;
 impl ColorCommand for FormatCommand {
     fn run(
         &self,
-        out: &mut dyn Write,
+        out: &mut Output,
         matches: &ArgMatches,
         config: &Config,
         color: &Color,
@@ -49,14 +50,14 @@ impl ColorCommand for FormatCommand {
 
         if write_colored_line {
             writeln!(
-                out,
+                out.handle,
                 "{}",
                 config
                     .brush
                     .paint(output, color.text_color().ansi_style().on(color))
             )?;
         } else {
-            write!(out, "{}", output)?;
+            write!(out.handle, "{}", output)?;
         }
 
         Ok(())

--- a/src/cli/commands/gradient.rs
+++ b/src/cli/commands/gradient.rs
@@ -1,6 +1,8 @@
+use std::io::Write;
+
 use crate::colorspace::get_mixing_function;
 use crate::commands::prelude::*;
-use crate::commands::show::show_color;
+use crate::output::Output;
 
 use pastel::Fraction;
 
@@ -8,6 +10,7 @@ pub struct GradientCommand;
 
 impl GenericCommand for GradientCommand {
     fn run(&self, out: &mut dyn Write, matches: &ArgMatches, config: &Config) -> Result<()> {
+        let mut o = Output::new(out);
         let count = matches.value_of("number").expect("required argument");
         let count = count
             .parse::<usize>()
@@ -35,7 +38,7 @@ impl GenericCommand for GradientCommand {
             let fraction = Fraction::from(i as f64 / (count as f64 - 1.0));
             let color = mix(&start, &stop, fraction);
 
-            show_color(out, &config, &color)?;
+            o.show_color(&config, &color)?;
         }
 
         Ok(())

--- a/src/cli/commands/gradient.rs
+++ b/src/cli/commands/gradient.rs
@@ -1,5 +1,3 @@
-use std::io::Write;
-
 use crate::colorspace::get_mixing_function;
 use crate::commands::prelude::*;
 use crate::output::Output;
@@ -9,8 +7,7 @@ use pastel::Fraction;
 pub struct GradientCommand;
 
 impl GenericCommand for GradientCommand {
-    fn run(&self, out: &mut dyn Write, matches: &ArgMatches, config: &Config) -> Result<()> {
-        let mut o = Output::new(out);
+    fn run(&self, out: &mut Output, matches: &ArgMatches, config: &Config) -> Result<()> {
         let count = matches.value_of("number").expect("required argument");
         let count = count
             .parse::<usize>()
@@ -38,7 +35,7 @@ impl GenericCommand for GradientCommand {
             let fraction = Fraction::from(i as f64 / (count as f64 - 1.0));
             let color = mix(&start, &stop, fraction);
 
-            o.show_color(&config, &color)?;
+            out.show_color(&config, &color)?;
         }
 
         Ok(())

--- a/src/cli/commands/gradient.rs
+++ b/src/cli/commands/gradient.rs
@@ -1,6 +1,5 @@
 use crate::colorspace::get_mixing_function;
 use crate::commands::prelude::*;
-use crate::output::Output;
 
 use pastel::Fraction;
 

--- a/src/cli/commands/gray.rs
+++ b/src/cli/commands/gray.rs
@@ -1,5 +1,7 @@
+use std::io::Write;
+
 use crate::commands::prelude::*;
-use crate::commands::show::show_color;
+use crate::output::Output;
 
 use pastel::Color;
 
@@ -7,8 +9,9 @@ pub struct GrayCommand;
 
 impl GenericCommand for GrayCommand {
     fn run(&self, out: &mut dyn Write, matches: &ArgMatches, config: &Config) -> Result<()> {
+        let mut o = Output::new(out);
         let lightness = number_arg(matches, "lightness")?;
         let gray = Color::graytone(lightness);
-        show_color(out, &config, &gray)
+        o.show_color(&config, &gray)
     }
 }

--- a/src/cli/commands/gray.rs
+++ b/src/cli/commands/gray.rs
@@ -1,5 +1,3 @@
-use std::io::Write;
-
 use crate::commands::prelude::*;
 use crate::output::Output;
 
@@ -8,10 +6,9 @@ use pastel::Color;
 pub struct GrayCommand;
 
 impl GenericCommand for GrayCommand {
-    fn run(&self, out: &mut dyn Write, matches: &ArgMatches, config: &Config) -> Result<()> {
-        let mut o = Output::new(out);
+    fn run(&self, out: &mut Output, matches: &ArgMatches, config: &Config) -> Result<()> {
         let lightness = number_arg(matches, "lightness")?;
         let gray = Color::graytone(lightness);
-        o.show_color(&config, &gray)
+        out.show_color(&config, &gray)
     }
 }

--- a/src/cli/commands/gray.rs
+++ b/src/cli/commands/gray.rs
@@ -1,5 +1,4 @@
 use crate::commands::prelude::*;
-use crate::output::Output;
 
 use pastel::Color;
 

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -1,7 +1,6 @@
 use crate::commands::prelude::*;
 use crate::commands::sort::key_function;
 use crate::named::{NamedColor, NAMED_COLORS};
-use crate::output::Output;
 
 use pastel::ansi::ToAnsiStyle;
 

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -1,15 +1,14 @@
-use std::io::{self, Write};
-
 use crate::commands::prelude::*;
 use crate::commands::sort::key_function;
 use crate::named::{NamedColor, NAMED_COLORS};
+use crate::output::Output;
 
 use pastel::ansi::ToAnsiStyle;
 
 pub struct ListCommand;
 
 impl GenericCommand for ListCommand {
-    fn run(&self, out: &mut dyn Write, matches: &ArgMatches, config: &Config) -> Result<()> {
+    fn run(&self, out: &mut Output, matches: &ArgMatches, config: &Config) -> Result<()> {
         let sort_order = matches.value_of("sort-order").expect("required argument");
 
         let mut colors: Vec<&NamedColor> = NAMED_COLORS.iter().map(|r| r).collect();
@@ -21,7 +20,7 @@ impl GenericCommand for ListCommand {
                 let bg = &nc.color;
                 let fg = bg.text_color();
                 writeln!(
-                    out,
+                    out.handle,
                     "{}",
                     config
                         .brush
@@ -29,10 +28,8 @@ impl GenericCommand for ListCommand {
                 )?;
             }
         } else {
-            let stdout = io::stdout();
-            let mut out = stdout.lock();
             for nc in colors {
-                let res = writeln!(out, "{}", nc.name);
+                let res = writeln!(out.handle, "{}", nc.name);
                 if res.is_err() {
                     break;
                 }

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -1,5 +1,6 @@
 use crate::config::Config;
 use crate::error::Result;
+use crate::output::Output;
 use clap::ArgMatches;
 
 mod color_commands;
@@ -69,7 +70,8 @@ impl Command {
 
     pub fn execute(&self, matches: &ArgMatches, config: &Config) -> Result<()> {
         let stdout = std::io::stdout();
-        let mut out = stdout.lock();
+        let mut stdout_lock = stdout.lock();
+        let mut out = Output::new(&mut stdout_lock);
 
         match self {
             Command::Generic(cmd) => cmd.run(&mut out, matches, config),

--- a/src/cli/commands/paint.rs
+++ b/src/cli/commands/paint.rs
@@ -1,6 +1,7 @@
 use std::io::{self, Read};
 
 use crate::commands::prelude::*;
+use crate::output::Output;
 use crate::parser::parse_color;
 
 use super::io::ColorArgIterator;
@@ -10,7 +11,7 @@ use pastel::ansi::Style;
 pub struct PaintCommand;
 
 impl GenericCommand for PaintCommand {
-    fn run(&self, out: &mut dyn Write, matches: &ArgMatches, config: &Config) -> Result<()> {
+    fn run(&self, out: &mut Output, matches: &ArgMatches, config: &Config) -> Result<()> {
         let fg = matches.value_of("color").expect("required argument");
         let fg = if fg.trim() == "default" {
             None
@@ -53,7 +54,7 @@ impl GenericCommand for PaintCommand {
         style.underline(matches.is_present("underline"));
 
         write!(
-            out,
+            out.handle,
             "{}{}",
             config.brush.paint(text, style),
             if matches.is_present("no-newline") {

--- a/src/cli/commands/paint.rs
+++ b/src/cli/commands/paint.rs
@@ -1,7 +1,6 @@
 use std::io::{self, Read};
 
 use crate::commands::prelude::*;
-use crate::output::Output;
 use crate::parser::parse_color;
 
 use super::io::ColorArgIterator;

--- a/src/cli/commands/pick.rs
+++ b/src/cli/commands/pick.rs
@@ -1,5 +1,3 @@
-use std::io::Write;
-
 use crate::commands::prelude::*;
 use crate::output::Output;
 
@@ -8,14 +6,13 @@ use crate::colorpicker::{print_colorspectrum, run_external_colorpicker};
 pub struct PickCommand;
 
 impl GenericCommand for PickCommand {
-    fn run(&self, out: &mut dyn Write, _: &ArgMatches, config: &Config) -> Result<()> {
-        let mut o = Output::new(out);
+    fn run(&self, out: &mut Output, _: &ArgMatches, config: &Config) -> Result<()> {
         print_colorspectrum(config)?;
         let color_str = run_external_colorpicker()?;
 
         let mut print_spectrum = PrintSpectrum::No;
         let color = ColorArgIterator::from_color_arg(config, &color_str, &mut print_spectrum)?;
-        o.show_color(config, &color)?;
+        out.show_color(config, &color)?;
 
         Ok(())
     }

--- a/src/cli/commands/pick.rs
+++ b/src/cli/commands/pick.rs
@@ -1,5 +1,4 @@
 use crate::commands::prelude::*;
-use crate::output::Output;
 
 use crate::colorpicker::{print_colorspectrum, run_external_colorpicker};
 

--- a/src/cli/commands/pick.rs
+++ b/src/cli/commands/pick.rs
@@ -1,5 +1,7 @@
+use std::io::Write;
+
 use crate::commands::prelude::*;
-use crate::commands::show::show_color;
+use crate::output::Output;
 
 use crate::colorpicker::{print_colorspectrum, run_external_colorpicker};
 
@@ -7,12 +9,13 @@ pub struct PickCommand;
 
 impl GenericCommand for PickCommand {
     fn run(&self, out: &mut dyn Write, _: &ArgMatches, config: &Config) -> Result<()> {
+        let mut o = Output::new(out);
         print_colorspectrum(config)?;
         let color_str = run_external_colorpicker()?;
 
         let mut print_spectrum = PrintSpectrum::No;
         let color = ColorArgIterator::from_color_arg(config, &color_str, &mut print_spectrum)?;
-        show_color(out, config, &color)?;
+        o.show_color(config, &color)?;
 
         Ok(())
     }

--- a/src/cli/commands/prelude.rs
+++ b/src/cli/commands/prelude.rs
@@ -1,5 +1,3 @@
-pub use std::io::Write;
-
 pub use crate::config::Config;
 pub use crate::error::{PastelError, Result};
 

--- a/src/cli/commands/prelude.rs
+++ b/src/cli/commands/prelude.rs
@@ -1,5 +1,6 @@
 pub use crate::config::Config;
 pub use crate::error::{PastelError, Result};
+pub use crate::output::Output;
 
 pub use clap::ArgMatches;
 

--- a/src/cli/commands/random.rs
+++ b/src/cli/commands/random.rs
@@ -1,5 +1,3 @@
-use std::io::Write;
-
 use crate::commands::prelude::*;
 use crate::output::Output;
 
@@ -9,8 +7,7 @@ use pastel::random::RandomizationStrategy;
 pub struct RandomCommand;
 
 impl GenericCommand for RandomCommand {
-    fn run(&self, out: &mut dyn Write, matches: &ArgMatches, config: &Config) -> Result<()> {
-        let mut o = Output::new(out);
+    fn run(&self, out: &mut Output, matches: &ArgMatches, config: &Config) -> Result<()> {
         let strategy_arg = matches.value_of("strategy").expect("required argument");
 
         let count = matches.value_of("number").expect("required argument");
@@ -27,7 +24,7 @@ impl GenericCommand for RandomCommand {
         };
 
         for _ in 0..count {
-            o.show_color(&config, &strategy.generate())?;
+            out.show_color(&config, &strategy.generate())?;
         }
 
         Ok(())

--- a/src/cli/commands/random.rs
+++ b/src/cli/commands/random.rs
@@ -1,5 +1,7 @@
+use std::io::Write;
+
 use crate::commands::prelude::*;
-use crate::commands::show::show_color;
+use crate::output::Output;
 
 use pastel::random::strategies;
 use pastel::random::RandomizationStrategy;
@@ -8,6 +10,7 @@ pub struct RandomCommand;
 
 impl GenericCommand for RandomCommand {
     fn run(&self, out: &mut dyn Write, matches: &ArgMatches, config: &Config) -> Result<()> {
+        let mut o = Output::new(out);
         let strategy_arg = matches.value_of("strategy").expect("required argument");
 
         let count = matches.value_of("number").expect("required argument");
@@ -24,7 +27,7 @@ impl GenericCommand for RandomCommand {
         };
 
         for _ in 0..count {
-            show_color(out, &config, &strategy.generate())?;
+            o.show_color(&config, &strategy.generate())?;
         }
 
         Ok(())

--- a/src/cli/commands/random.rs
+++ b/src/cli/commands/random.rs
@@ -1,5 +1,4 @@
 use crate::commands::prelude::*;
-use crate::output::Output;
 
 use pastel::random::strategies;
 use pastel::random::RandomizationStrategy;

--- a/src/cli/commands/show.rs
+++ b/src/cli/commands/show.rs
@@ -6,11 +6,11 @@ pub struct ShowCommand;
 impl ColorCommand for ShowCommand {
     fn run(
         &self,
-        out: &mut dyn Write,
+        out: &mut Output,
         _: &ArgMatches,
         config: &Config,
         color: &Color,
     ) -> Result<()> {
-        (Output::new(out)).show_color(config, color)
+        out.show_color(config, color)
     }
 }

--- a/src/cli/commands/show.rs
+++ b/src/cli/commands/show.rs
@@ -83,8 +83,17 @@ pub fn show_color_tty(out: &mut dyn Write, config: &Config, color: &Color) -> Re
 }
 
 pub fn show_color(out: &mut dyn Write, config: &Config, color: &Color) -> Result<()> {
+    // ref: https://stackoverflow.com/questions/27791532/how-do-i-create-a-global-mutable-singleton @@ https://archive.is/5aygT
+    use std::sync::atomic::{AtomicBool, Ordering};
+    // use std::sync::atomic::{AtomicUsize, Ordering};
+    static SWATCH_FIRST: AtomicBool = AtomicBool::new(true);
+    // static SWATCH_COUNT: AtomicUsize = AtomicUsize::new(0);
+
     if config.interactive_mode {
+        if SWATCH_FIRST.fetch_and(false, Ordering::SeqCst) { writeln!(out)? };
+        // if SWATCH_COUNT.fetch_add(1, Ordering::SeqCst) < 1 { writeln!(out)? };
         show_color_tty(out, config, color)?;
+        writeln!(out)?;
     } else {
         writeln!(out, "{}", color.to_hsl_string(Format::NoSpaces))?;
     }

--- a/src/cli/commands/show.rs
+++ b/src/cli/commands/show.rs
@@ -1,105 +1,5 @@
 use crate::commands::prelude::*;
-
-use crate::hdcanvas::Canvas;
-use crate::utility::similar_colors;
-
-use pastel::Format;
-
-pub fn show_color_tty(out: &mut dyn Write, config: &Config, color: &Color) -> Result<()> {
-    let checkerboard_size: usize = 16;
-    let color_panel_size: usize = 12;
-
-    let checkerboard_position_y: usize = 0;
-    let checkerboard_position_x: usize = config.padding;
-    let color_panel_position_y: usize = checkerboard_position_y + (checkerboard_size - color_panel_size) / 2;
-    let color_panel_position_x: usize = config.padding + (checkerboard_size - color_panel_size) / 2;
-    let text_position_x: usize = checkerboard_size + 2 * config.padding;
-    let text_position_y: usize = 0;
-
-    let mut canvas = Canvas::new(checkerboard_size, 51, config.brush);
-    canvas.draw_checkerboard(
-        checkerboard_position_y,
-        checkerboard_position_x,
-        checkerboard_size,
-        checkerboard_size,
-        &Color::graytone(0.94),
-        &Color::graytone(0.71),
-    );
-    canvas.draw_rect(
-        color_panel_position_y,
-        color_panel_position_x,
-        color_panel_size,
-        color_panel_size,
-        color,
-    );
-
-    let mut text_y_offset = 0;
-    let similar = similar_colors(&color);
-
-    for (i, nc) in similar.iter().enumerate().take(3) {
-        if nc.color == *color {
-            canvas.draw_text(
-                text_position_y,
-                text_position_x,
-                &format!("Name: {}", nc.name),
-            );
-            text_y_offset = 2;
-            continue;
-        }
-
-        canvas.draw_text(text_position_y + 10 + 2 * i, text_position_x + 7, nc.name);
-        canvas.draw_rect(
-            text_position_y + 10 + 2 * i,
-            text_position_x + 1,
-            2,
-            5,
-            &nc.color,
-        );
-    }
-
-    canvas.draw_text(
-        text_position_y + 0 + text_y_offset,
-        text_position_x,
-        &format!("Hex: {}", color.to_rgb_hex_string(true)),
-    );
-    canvas.draw_text(
-        text_position_y + 2 + text_y_offset,
-        text_position_x,
-        &format!("RGB: {}", color.to_rgb_string(Format::Spaces)),
-    );
-    canvas.draw_text(
-        text_position_y + 4 + text_y_offset,
-        text_position_x,
-        &format!("HSL: {}", color.to_hsl_string(Format::Spaces)),
-    );
-
-    canvas.draw_text(
-        text_position_y + 8 + text_y_offset,
-        text_position_x,
-        "Most similar:",
-    );
-
-    canvas.print(out)
-}
-
-pub fn show_color(out: &mut dyn Write, config: &Config, color: &Color) -> Result<()> {
-    // ref: https://stackoverflow.com/questions/27791532/how-do-i-create-a-global-mutable-singleton @@ https://archive.is/5aygT
-    use std::sync::atomic::{AtomicBool, Ordering};
-    // use std::sync::atomic::{AtomicUsize, Ordering};
-    static SWATCH_FIRST: AtomicBool = AtomicBool::new(true);
-    // static SWATCH_COUNT: AtomicUsize = AtomicUsize::new(0);
-
-    if config.interactive_mode {
-        if SWATCH_FIRST.fetch_and(false, Ordering::SeqCst) { writeln!(out)? };
-        // if SWATCH_COUNT.fetch_add(1, Ordering::SeqCst) < 1 { writeln!(out)? };
-        show_color_tty(out, config, color)?;
-        writeln!(out)?;
-    } else {
-        writeln!(out, "{}", color.to_hsl_string(Format::NoSpaces))?;
-    }
-
-    Ok(())
-}
+use crate::output::Output;
 
 pub struct ShowCommand;
 
@@ -111,6 +11,6 @@ impl ColorCommand for ShowCommand {
         config: &Config,
         color: &Color,
     ) -> Result<()> {
-        show_color(out, config, color)
+        (Output::new(out)).show_color(config, color)
     }
 }

--- a/src/cli/commands/show.rs
+++ b/src/cli/commands/show.rs
@@ -9,22 +9,25 @@ pub fn show_color_tty(out: &mut dyn Write, config: &Config, color: &Color) -> Re
     let checkerboard_size: usize = 16;
     let color_panel_size: usize = 12;
 
-    let color_panel_position: usize = config.padding + (checkerboard_size - color_panel_size) / 2;
+    let checkerboard_position_y: usize = 0;
+    let checkerboard_position_x: usize = config.padding;
+    let color_panel_position_y: usize = checkerboard_position_y + (checkerboard_size - color_panel_size) / 2;
+    let color_panel_position_x: usize = config.padding + (checkerboard_size - color_panel_size) / 2;
     let text_position_x: usize = checkerboard_size + 2 * config.padding;
-    let text_position_y: usize = config.padding + 0;
+    let text_position_y: usize = 0;
 
-    let mut canvas = Canvas::new(2 * config.padding + checkerboard_size, 55, config.brush);
+    let mut canvas = Canvas::new(checkerboard_size, 51, config.brush);
     canvas.draw_checkerboard(
-        config.padding,
-        config.padding,
+        checkerboard_position_y,
+        checkerboard_position_x,
         checkerboard_size,
         checkerboard_size,
         &Color::graytone(0.94),
         &Color::graytone(0.71),
     );
     canvas.draw_rect(
-        color_panel_position,
-        color_panel_position,
+        color_panel_position_y,
+        color_panel_position_x,
         color_panel_size,
         color_panel_size,
         color,

--- a/src/cli/commands/show.rs
+++ b/src/cli/commands/show.rs
@@ -6,12 +6,12 @@ use crate::utility::similar_colors;
 use pastel::Format;
 
 pub fn show_color_tty(out: &mut dyn Write, config: &Config, color: &Color) -> Result<()> {
-    let checkerboard_size: usize = 20;
-    let color_panel_size: usize = 14;
+    let checkerboard_size: usize = 16;
+    let color_panel_size: usize = 12;
 
     let color_panel_position: usize = config.padding + (checkerboard_size - color_panel_size) / 2;
     let text_position_x: usize = checkerboard_size + 2 * config.padding;
-    let text_position_y: usize = config.padding + 2;
+    let text_position_y: usize = config.padding + 0;
 
     let mut canvas = Canvas::new(2 * config.padding + checkerboard_size, 55, config.brush);
     canvas.draw_checkerboard(

--- a/src/cli/commands/show.rs
+++ b/src/cli/commands/show.rs
@@ -1,5 +1,4 @@
 use crate::commands::prelude::*;
-use crate::output::Output;
 
 pub struct ShowCommand;
 

--- a/src/cli/commands/sort.rs
+++ b/src/cli/commands/sort.rs
@@ -1,7 +1,6 @@
 use rand::prelude::*;
 
 use crate::commands::prelude::*;
-use crate::output::Output;
 
 pub struct SortCommand;
 

--- a/src/cli/commands/sort.rs
+++ b/src/cli/commands/sort.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use rand::prelude::*;
 
 use crate::commands::prelude::*;
-use crate::commands::show::show_color;
+use crate::output::Output;
 
 pub struct SortCommand;
 
@@ -20,6 +20,7 @@ pub fn key_function(sort_order: &str, color: &Color) -> i32 {
 
 impl GenericCommand for SortCommand {
     fn run(&self, out: &mut dyn Write, matches: &ArgMatches, config: &Config) -> Result<()> {
+        let mut o = Output::new(out);
         let sort_order = matches.value_of("sort-order").expect("required argument");
 
         let mut colors: Vec<Color> = vec![];
@@ -39,7 +40,7 @@ impl GenericCommand for SortCommand {
         }
 
         for color in colors {
-            show_color(out, config, &color)?;
+            o.show_color(config, &color)?;
         }
 
         Ok(())

--- a/src/cli/commands/sort.rs
+++ b/src/cli/commands/sort.rs
@@ -1,5 +1,3 @@
-use std::io::Write;
-
 use rand::prelude::*;
 
 use crate::commands::prelude::*;
@@ -19,8 +17,7 @@ pub fn key_function(sort_order: &str, color: &Color) -> i32 {
 }
 
 impl GenericCommand for SortCommand {
-    fn run(&self, out: &mut dyn Write, matches: &ArgMatches, config: &Config) -> Result<()> {
-        let mut o = Output::new(out);
+    fn run(&self, out: &mut Output, matches: &ArgMatches, config: &Config) -> Result<()> {
         let sort_order = matches.value_of("sort-order").expect("required argument");
 
         let mut colors: Vec<Color> = vec![];
@@ -40,7 +37,7 @@ impl GenericCommand for SortCommand {
         }
 
         for color in colors {
-            o.show_color(config, &color)?;
+            out.show_color(config, &color)?;
         }
 
         Ok(())

--- a/src/cli/commands/traits.rs
+++ b/src/cli/commands/traits.rs
@@ -1,6 +1,5 @@
-use std::io::Write;
-
 use crate::config::Config;
+use crate::output::Output;
 use crate::Result;
 
 use clap::ArgMatches;
@@ -8,13 +7,13 @@ use clap::ArgMatches;
 use pastel::Color;
 
 pub trait GenericCommand {
-    fn run(&self, out: &mut dyn Write, matches: &ArgMatches, config: &Config) -> Result<()>;
+    fn run(&self, out: &mut Output, matches: &ArgMatches, config: &Config) -> Result<()>;
 }
 
 pub trait ColorCommand {
     fn run(
         &self,
-        out: &mut dyn Write,
+        out: &mut Output,
         matches: &ArgMatches,
         config: &Config,
         color: &Color,

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -10,6 +10,7 @@ mod config;
 mod error;
 mod hdcanvas;
 mod named;
+mod output;
 mod parser;
 mod utility;
 

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -1,0 +1,97 @@
+use std::io::Write;
+
+use crate::config::Config;
+use crate::error::Result;
+use crate::hdcanvas::Canvas;
+use crate::utility::similar_colors;
+
+use pastel::Color;
+use pastel::Format;
+
+// #[derive(Debug)]
+pub struct Output<'a> {
+    pub handle: &'a mut dyn Write,
+    colors_shown: usize,
+}
+
+impl Output<'_> {
+    pub fn new(handle: &mut dyn Write) -> Output {
+        Output {
+            handle: handle,
+            colors_shown: 0
+        }
+    }
+
+    pub fn show_color_tty(&mut self, config: &Config, color: &Color) -> Result<()> {
+        let checkerboard_size: usize = 16;
+        let color_panel_size: usize = 12;
+
+        let checkerboard_position_y: usize = 0;
+        let checkerboard_position_x: usize = config.padding;
+        let color_panel_position_y: usize = checkerboard_position_y + (checkerboard_size - color_panel_size) / 2;
+        let color_panel_position_x: usize = config.padding + (checkerboard_size - color_panel_size) / 2;
+        let text_position_x: usize = checkerboard_size + 2 * config.padding;
+        let text_position_y: usize = 0;
+
+        let mut canvas = Canvas::new(checkerboard_size, 51, config.brush);
+        canvas.draw_checkerboard(
+            checkerboard_position_y,
+            checkerboard_position_x,
+            checkerboard_size,
+            checkerboard_size,
+            &Color::graytone(0.94),
+            &Color::graytone(0.71),
+        );
+        canvas.draw_rect(
+            color_panel_position_y,
+            color_panel_position_x,
+            color_panel_size,
+            color_panel_size,
+            color,
+        );
+
+        canvas.draw_text(
+            text_position_y + 0,
+            text_position_x,
+            &format!("Hex: {}", color.to_rgb_hex_string(true)),
+        );
+        canvas.draw_text(
+            text_position_y + 2,
+            text_position_x,
+            &format!("RGB: {}", color.to_rgb_string(Format::Spaces)),
+        );
+        canvas.draw_text(
+            text_position_y + 4,
+            text_position_x,
+            &format!("HSL: {}", color.to_hsl_string(Format::Spaces)),
+        );
+
+        canvas.draw_text(text_position_y + 8, text_position_x, "Most similar:");
+        let similar = similar_colors(&color);
+        for (i, nc) in similar.iter().enumerate().take(3) {
+            canvas.draw_text(text_position_y + 10 + 2 * i, text_position_x + 7, nc.name);
+            canvas.draw_rect(
+                text_position_y + 10 + 2 * i,
+                text_position_x + 1,
+                2,
+                5,
+                &nc.color,
+            );
+        }
+
+        canvas.print(self.handle)
+    }
+
+    pub fn show_color(&mut self, config: &Config, color: &Color) -> Result<()> {
+        if config.interactive_mode {
+            if self.colors_shown < 1 { writeln!(self.handle)? };
+            self.show_color_tty(config, color)?;
+            writeln!(self.handle)?;
+        } else {
+            writeln!(self.handle, "{}", color.to_hsl_string(Format::NoSpaces))?;
+        }
+        self.colors_shown += 1;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Here's the PR I promised.

I've separated it into three commits: 1) the repair commit (swatch/checkerboard resize) [5f7bf24], 2) removal of vertical padding between swatches [66eba3f], 3) adding vertical padding under outer function control to allow for better visual symmetry of output (otherwise, there's extra padding either at the top or bottom) [462b00a].

To get a one-of vertical padding line at the top of the output, I used an `atomic` boolean as state. It feels like a hack, but I'm not sure of a better "safe"-function way. Adding an iterator to the functions interface seems like a less desirable, more heavy-handed approach.

So, I left the commits separate for easier modification to a final result.

I think the final result looks good. And the `atomic`, while a bit hack-ish, should be lock-free and speedy per the documentation.

Thoughts?