### PR TITLE
weight hue by chroma in mix()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -669,8 +669,8 @@ impl ColorSpace for HSLA {
     }
 
     fn mix(&self, other: &Self, fraction: Fraction) -> Self {
-        let f1 = fraction.value() * other.s;
-        let f2 = (1.0 - fraction.value()) * self.s;
+        let f1 = fraction.value() * other.s * other.l;
+        let f2 = (1.0 - fraction.value()) * self.s * self.l;
         let angle_fraction = Fraction::from(f1 / (f1 + f2));
         Self {
             h: interpolate_angle(self.h, other.h, angle_fraction),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -669,8 +669,11 @@ impl ColorSpace for HSLA {
     }
 
     fn mix(&self, other: &Self, fraction: Fraction) -> Self {
+        let f1 = fraction.value() * other.s;
+        let f2 = (1.0 - fraction.value()) * self.s;
+        let angle_fraction = Fraction::from(f1 / (f1 + f2));
         Self {
-            h: interpolate_angle(self.h, other.h, fraction),
+            h: interpolate_angle(self.h, other.h, angle_fraction),
             s: interpolate(self.s, other.s, fraction),
             l: interpolate(self.l, other.l, fraction),
             alpha: interpolate(self.alpha, other.alpha, fraction),
@@ -731,10 +734,13 @@ impl ColorSpace for LCh {
     }
 
     fn mix(&self, other: &Self, fraction: Fraction) -> Self {
+        let f1 = fraction.value() * other.c;
+        let f2 = (1.0 - fraction.value()) * self.c;
+        let angle_fraction = Fraction::from(f1 / (f1 + f2));
         Self {
             l: interpolate(self.l, other.l, fraction),
             c: interpolate(self.c, other.c, fraction),
-            h: interpolate_angle(self.h, other.h, fraction),
+            h: interpolate_angle(self.h, other.h, angle_fraction),
             alpha: interpolate(self.alpha, other.alpha, fraction),
         }
     }


### PR DESCRIPTION
For unsaturated colors, the hue is not as relevant. Consider mixing black and blue:

```
$ pastel mix -s hsl black blue
#602060
```

As black does not have a meaningful hue, it is assumed to be 0 (red). So the result is a dark purple instead of a dark blue.

My proposal is to weight the hues  by saturation. So in the example above, the red hue of black would be ignored because it has a saturation of 0. I understad this is more complex but does ultimately lead to less unexpected results.

(I did not do anything special to prevent devision by zero. rust seems to  be smart enough to handle that itself, but I am not proficient enough to know exactly how.)