### PR TITLE
Implemented colorblindness simulations

### DIFF
--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -307,6 +307,24 @@ pub fn build_cli() -> App<'static, 'static> {
                 .arg(color_arg.clone()),
         )
         .subcommand(
+            SubCommand::with_name("colorblind")
+                .about("Simulate a color under a certain colorblindness profile")
+                .long_about(
+                    "Convert the given color to how it would look to a person with protanopia, \
+                    deuteranopia, or tritanopia \n\n\
+                     Example:\n  \
+                       pastel random | pastel colorblind deut")
+                .arg(
+                    Arg::with_name("type")
+                        .help("The type of colorblindness that should be simulated (protanopia, \
+                               deuteranopia, tritanopia)")
+                        .possible_values(&["pro", "deut", "tri"])
+                        .case_insensitive(true)
+                        .required(true),
+                )
+                .arg(color_arg.clone()),
+        )
+        .subcommand(
             SubCommand::with_name("set")
                 .about("Set a color property to a specific value")
                 .long_about("Set the given property to a specific value\n\

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -313,12 +313,12 @@ pub fn build_cli() -> App<'static, 'static> {
                     "Convert the given color to how it would look to a person with protanopia, \
                     deuteranopia, or tritanopia \n\n\
                      Example:\n  \
-                       pastel distinct 3 | pastel colorblind deut")
+                       pastel distinct 3 | pastel colorblind deuter")
                 .arg(
                     Arg::with_name("type")
                         .help("The type of colorblindness that should be simulated (protanopia, \
                                deuteranopia, tritanopia)")
-                        .possible_values(&["pro", "deut", "tri"])
+                        .possible_values(&["prot", "deuter", "trit"])
                         .case_insensitive(true)
                         .required(true),
                 )

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -313,7 +313,7 @@ pub fn build_cli() -> App<'static, 'static> {
                     "Convert the given color to how it would look to a person with protanopia, \
                     deuteranopia, or tritanopia \n\n\
                      Example:\n  \
-                       pastel random | pastel colorblind deut")
+                       pastel distinct 3 | pastel colorblind deut")
                 .arg(
                     Arg::with_name("type")
                         .help("The type of colorblindness that should be simulated (protanopia, \

--- a/src/cli/commands/color_commands.rs
+++ b/src/cli/commands/color_commands.rs
@@ -1,6 +1,7 @@
 use crate::colorspace::get_mixing_function;
 use crate::commands::prelude::*;
 use pastel::Fraction;
+use pastel::LMS;
 
 fn clamp(lower: f64, upper: f64, x: f64) -> f64 {
     f64::max(f64::min(upper, x), lower)
@@ -75,6 +76,37 @@ color_command!(MixCommand, config, matches, color, {
     let mix = get_mixing_function(matches.value_of("colorspace").expect("required argument"));
 
     mix(&base, &color, fraction)
+});
+
+color_command!(ColorblindCommand, config, matches, color, {
+    // The type of colorblindness selected (protanopia, deuteranopia, tritanopia)
+    let cb_ty = matches.value_of("type").expect("required argument");
+    let cb_ty = cb_ty.to_lowercase();
+
+    // Coefficients here are taken from
+    // https://ixora.io/projects/colorblindness/color-blindness-simulation-research/
+    let (l, m, s, alpha) = match cb_ty.as_ref() {
+        "pro" => {
+            let LMS { m, s, alpha, .. } = color.to_lms();
+            let l = 1.05118294 * m - 0.05116099 * s;
+            (l, m, s, alpha)
+        }
+        "deut" => {
+            let LMS { l, s, alpha, .. } = color.to_lms();
+            let m = 0.9513092 * l + 0.04866992 * s;
+            (l, m, s, alpha)
+        }
+        "tri" => {
+            let LMS { l, m, alpha, .. } = color.to_lms();
+            let s = -0.86744736 * l + 1.86727089 * m;
+            (l, m, s, alpha)
+        }
+        &_ => {
+            unreachable!("Unknown property");
+        }
+    };
+
+    Color::from_lms(l, m, s, alpha)
 });
 
 color_command!(SetCommand, config, matches, color, {

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -47,6 +47,7 @@ impl Command {
             "lighten" => Command::WithColor(Box::new(color_commands::LightenCommand)),
             "darken" => Command::WithColor(Box::new(color_commands::DarkenCommand)),
             "rotate" => Command::WithColor(Box::new(color_commands::RotateCommand)),
+            "colorblind" => Command::WithColor(Box::new(color_commands::ColorblindCommand)),
             "set" => Command::WithColor(Box::new(color_commands::SetCommand)),
             "complement" => Command::WithColor(Box::new(color_commands::ComplementCommand)),
             "mix" => Command::WithColor(Box::new(color_commands::MixCommand)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -815,7 +815,7 @@ impl ColorSpace for LCh {
 /// A representation of the different kinds of colorblindness. More info
 /// [here](https://en.wikipedia.org/wiki/Color_blindness).
 pub enum ColorblindnessType {
-    /// Protonopic people lack red cones
+    /// Protanopic people lack red cones
     Protanopia,
     /// Deuteranopic people lack green cones
     Deuteranopia,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,15 @@ impl Color {
         Self::from_rgba_float(r, g, b, alpha)
     }
 
+    /// Create a `Color` from LMS coordinates. This is the matrix inverse of the matrix that
+    /// appears in `to_lms`.
+    pub fn from_lms(l: Scalar, m: Scalar, s: Scalar, alpha: Scalar) -> Color {
+        let x = 1.91020 * l - 1.112120 * m + 0.201908 * s;
+        let y = 0.37095 * l + 0.629054 * m + 0.000000 * s;
+        let z = 0.00000 * l + 0.000000 * m + 1.000000 * s;
+        Color::from_xyz(x, y, z, alpha)
+    }
+
     /// Create a `Color` from L, a and b coordinates coordinates in the Lab color
     /// space. Note: See documentation for `from_xyz`. The same restrictions apply here.
     ///
@@ -314,6 +323,19 @@ impl Color {
             z,
             alpha: self.alpha,
         }
+    }
+
+    /// Get coordinates according to the LSM color space
+    ///
+    /// See https://en.wikipedia.org/wiki/LMS_color_space for info on the color space as well as an
+    /// algorithm for converting from CIE XYZ
+    pub fn to_lms(&self) -> LMS {
+        let XYZ { x, y, z, alpha } = self.to_xyz();
+        let l = 0.38971 * x + 0.68898 * y - 0.07868 * z;
+        let m = -0.22981 * x + 1.18340 * y + 0.04641 * z;
+        let s = 0.00000 * x + 0.00000 * y + 1.00000 * z;
+
+        LMS { l, m, s, alpha }
     }
 
     /// Get L, a and b coordinates according to the Lab color space.
@@ -699,6 +721,14 @@ pub struct XYZ {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct LMS {
+    pub l: Scalar,
+    pub m: Scalar,
+    pub s: Scalar,
+    pub alpha: Scalar,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct Lab {
     pub l: Scalar,
     pub a: Scalar,
@@ -884,6 +914,20 @@ mod tests {
             let color1 = Color::from_hsl(h, s, l);
             let xyz1 = color1.to_xyz();
             let color2 = Color::from_xyz(xyz1.x, xyz1.y, xyz1.z, 1.0);
+            assert_almost_equal(&color1, &color2);
+        };
+
+        for hue in 0..360 {
+            roundtrip(Scalar::from(hue), 0.2, 0.8);
+        }
+    }
+
+    #[test]
+    fn lms_conversion() {
+        let roundtrip = |h, s, l| {
+            let color1 = Color::from_hsl(h, s, l);
+            let lms1 = color1.to_lms();
+            let color2 = Color::from_lms(lms1.l, lms1.m, lms1.s, 1.0);
             assert_almost_equal(&color1, &color2);
         };
 


### PR DESCRIPTION
I wrote an XYZ <-> LMS conversion so that the protanopia, deteranopia, and tritanopia filters can be applied in the LMS space and then converted back to whatever.

Usage example:

```pastel color a3247b | pastel colorblind deut```

Issue: The output doesn't *exactly* match what I see with [Color Oracle](https://colororacle.org/), but it's pretty close.