### PR TITLE
Show color name

### DIFF
--- a/src/cli/commands/show.rs
+++ b/src/cli/commands/show.rs
@@ -30,25 +30,20 @@ pub fn show_color_tty(out: &mut dyn Write, config: &Config, color: &Color) -> Re
         color,
     );
 
-    canvas.draw_text(
-        text_position_y + 0,
-        text_position_x,
-        &format!("Hex: {}", color.to_rgb_hex_string(true)),
-    );
-    canvas.draw_text(
-        text_position_y + 2,
-        text_position_x,
-        &format!("RGB: {}", color.to_rgb_string(Format::Spaces)),
-    );
-    canvas.draw_text(
-        text_position_y + 4,
-        text_position_x,
-        &format!("HSL: {}", color.to_hsl_string(Format::Spaces)),
-    );
-
-    canvas.draw_text(text_position_y + 8, text_position_x, "Most similar:");
+    let mut text_y_offset = 0;
     let similar = similar_colors(&color);
+
     for (i, nc) in similar.iter().enumerate().take(3) {
+        if nc.color == *color {
+            canvas.draw_text(
+                text_position_y,
+                text_position_x,
+                &format!("Name: {}", nc.name),
+            );
+            text_y_offset = 2;
+            continue;
+        }
+
         canvas.draw_text(text_position_y + 10 + 2 * i, text_position_x + 7, nc.name);
         canvas.draw_rect(
             text_position_y + 10 + 2 * i,
@@ -58,6 +53,28 @@ pub fn show_color_tty(out: &mut dyn Write, config: &Config, color: &Color) -> Re
             &nc.color,
         );
     }
+
+    canvas.draw_text(
+        text_position_y + 0 + text_y_offset,
+        text_position_x,
+        &format!("Hex: {}", color.to_rgb_hex_string(true)),
+    );
+    canvas.draw_text(
+        text_position_y + 2 + text_y_offset,
+        text_position_x,
+        &format!("RGB: {}", color.to_rgb_string(Format::Spaces)),
+    );
+    canvas.draw_text(
+        text_position_y + 4 + text_y_offset,
+        text_position_x,
+        &format!("HSL: {}", color.to_hsl_string(Format::Spaces)),
+    );
+
+    canvas.draw_text(
+        text_position_y + 8 + text_y_offset,
+        text_position_x,
+        "Most similar:",
+    );
 
     canvas.print(out)
 }

--- a/src/cli/utility.rs
+++ b/src/cli/utility.rs
@@ -4,7 +4,7 @@ use crate::named::{NamedColor, NAMED_COLORS};
 
 /// Returns a list of named colors, sorted by the perceived distance to the given color
 pub fn similar_colors(color: &Color) -> Vec<&NamedColor> {
-    let mut colors: Vec<&NamedColor> = NAMED_COLORS.iter().map(|r| r).collect();
+    let mut colors: Vec<&NamedColor> = NAMED_COLORS.iter().collect();
     colors.sort_by_key(|nc| (1000.0 * nc.color.distance_delta_e_ciede2000(&color)) as i32);
     colors.dedup_by(|n1, n2| n1.color == n2.color);
     colors


### PR DESCRIPTION
Should close #77 .

After experimenting with this a bit, I believe that it's a bit more clear to have a dedicated "Name: " section vs making the color more visible in the "Most similar" list. But that's only my opinion.

Let me know what you think.

Screenshot:

![](https://user-images.githubusercontent.com/6960399/63936292-c6f29000-ca5f-11e9-8d14-e43befc88626.png)
