### PR TITLE
Optimize distinct

### DIFF
--- a/src/distinct.rs
+++ b/src/distinct.rs
@@ -184,7 +184,7 @@ pub fn rearrange_sequence(colors: &mut Vec<Color>, metric: DistanceMetric) {
 
     for i in 1..colors.len() {
         let (left, right) = colors.split_at_mut(i);
-        right.sort_unstable_by_key(|c| {
+        right.sort_by_cached_key(|c| {
             left.iter()
                 .map(|c2| (-distance(c2, c) * 1000.0) as i32)
                 .max()

--- a/src/distinct.rs
+++ b/src/distinct.rs
@@ -182,13 +182,25 @@ pub fn rearrange_sequence(colors: &mut Vec<Color>, metric: DistanceMetric) {
         DistanceMetric::CIEDE2000 => c1.distance_delta_e_ciede2000(c2),
     };
 
+    // vector where the i-th element contains the minimum distance to the colors from 0 to i-1.
+    let mut min_distances = vec![i32::max_value(); colors.len()];
+
     for i in 1..colors.len() {
-        let (left, right) = colors.split_at_mut(i);
-        right.sort_by_cached_key(|c| {
-            left.iter()
-                .map(|c2| (-distance(c2, c) * 1000.0) as i32)
-                .max()
-        });
+        let mut max_i = colors.len();
+        let mut max_d = i32::min_value();
+
+        for j in i..colors.len() {
+            min_distances[j] =
+                min_distances[j].min((distance(&colors[j], &colors[i - 1]) * 1000.0) as i32);
+
+            if min_distances[j] > max_d {
+                max_i = j;
+                max_d = min_distances[j];
+            }
+        }
+
+        colors.swap(i, max_i);
+        min_distances.swap(i, max_i);
     }
 }
 

--- a/src/distinct.rs
+++ b/src/distinct.rs
@@ -19,7 +19,7 @@ pub struct DistanceResult {
     /// Indices of the colors that were closest to each other
     pub closest_pair: (usize, usize),
 
-    /// The closest distance and color index for each color
+    /// The closest distance and the index of the nearest neighbor
     pub closest_distances: Vec<(Scalar, usize)>,
 
     pub distance_metric: DistanceMetric,
@@ -245,12 +245,15 @@ impl DistanceResult {
 
             if dist < self.closest_distances[i].0 {
                 self.closest_distances[i] = (dist, color);
-                self.closest_distances[color] = (dist, i);
             } else if changed && self.closest_distances[i].1 == color {
                 // changed_color was the best before, but unfortunately we cannot say it now for
                 // sure because the distance between the two increased. Play it safe and just
                 // recalculate its distances.
                 to_recalc.push(i);
+            }
+
+            if dist < self.closest_distances[color].0 {
+                self.closest_distances[color] = (dist, i);
             }
         }
 


### PR DESCRIPTION
In this PR I've tried to speedup the distinct command by optimizing the simulated annealing process and the rearranging of colors.

Non scientific benchmarks show that in fact the proposed changes greatly improve performance. For example, now I'm able to run `pastel distinct 200 | cat` in <1 sec while without these changes it would have taken ~25secs on my machine. However, on small inputs the boost is not as big; in fact `pastel distinct 20 | cat` now runs in ~0.2secs vs ~0.4secs which is still better, but still a bit slow imho.

The simulated annealing was optimized mainly by avoiding to recalculate the distances from scratch every time , but by only recalculating the distances to the color that changed. This is the main contributing factor to the speedup.

After having optimized that, `cargo flamegraph` showed that a _bunch_ of time was spent inside the `rearrange_sequence` function. A first optimization was to simply switch to using `sort_by_cached_key` because calculating the key at each comparison is really too expensive. Then,  I went ahead and removed the sorting altogether because I think there was no need for it and introduced a cache for the minimum distances.

At this point I don't see any other low hanging fruits and I'm likely to stop here as I'm ok with the results.

Let me know what you think.

(also, your implementation of simulated annealing was really cool! simulated annealing is one of my favourite algorithms :smile:  )
