### PR TITLE
Add macOS built-in color picker capability

### DIFF
--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -175,7 +175,8 @@ pub fn build_cli() -> App<'static, 'static> {
                   - grabc (https://www.muquit.com/muquit/software/grabc/grabc.html)\n  \
                   - colorpicker (https://github.com/Jack12816/colorpicker)\n  \
                   - chameleon (https://github.com/seebye/chameleon)\n  \
-                  - KColorChooser (https://kde.org/applications/graphics/org.kde.kcolorchooser)")
+                  - KColorChooser (https://kde.org/applications/graphics/org.kde.kcolorchooser)\n  \
+                  - macOS built-in color picker")
         )
         .subcommand(
             SubCommand::with_name("format")


### PR DESCRIPTION
`osascript` is the built-in automation program in macOS.

The method of triggering the macOS color picker from `osascript` is documented here:
https://developer.apple.com/library/archive/documentation/LanguagesUtilities/Conceptual/MacAutomationScriptingGuide/PromptforaColor.html#//apple_ref/doc/uid/TP40016239-CH86-SW1

There is a weirdness of `osascript` in that `console.log` only writes to `stderr` regardless of the documented "write to stdout" flag. A workaround was found here and linked in the relevant comment: https://apple.stackexchange.com/a/278395

The picker is only attempted when `#[cfg(target_os = "macos")]`, however it's still listed in the "Supported tools" help text because `clap` make it somewhat hard to customize that help text (e.g. generating from the list of tools) because it does not take ownership of strings. Related: https://github.com/clap-rs/clap/issues/1041