### PR TITLE
fix for non-color consoles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ features = ["suggestions", "color", "wrap_help"]
 
 [build-dependencies]
 clap = "2"
+output_vt100 = "0.1"
 
 [[bin]]
 name = "pastel"

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -485,7 +485,7 @@ pub fn build_cli() -> App<'static, 'static> {
                 .value_name("mode")
                 .help("Specify the terminal color mode: 24bit, 8bit, off, *auto*")
                 .possible_values(&["24bit", "8bit", "off", "auto"])
-                .default_value("auto")
+                .default_value(if output_vt100::try_init().is_ok() {"auto"} else {"off"})
                 .hide_possible_values(true)
                 .hide_default_value(true)
         )

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -39,10 +39,6 @@ fn run() -> Result<ExitCode> {
 
     let interactive_mode = atty::is(Stream::Stdout);
 
-    if interactive_mode {
-        output_vt100::init();
-    }
-
     let color_mode = if global_matches.is_present("force-color") {
         Some(ansi::Mode::TrueColor)
     } else {


### PR DESCRIPTION
This is an initial version that compiles and works for Windows 7. I created a long note-to-self log message with reasoning and references (from [92de415c]) ...

```text
change ~ allow operation despite non-color output

* customize function for platforms without color support
- return only non-colorized output for "format", "list", and "paint" subcommands
- disable "colorcheck" and "pick" commands with an error

.# Discussion

Versions of Windows prior to one of the v1511 Windows 10 builds (likely
10.0.10586.589; released on 2016-09-13) do not have built-in console
interpretation of ANSI escapes. After Win10 v1511, ANSI escape interpretation
is available, when enabled via `SetConsoleMode()` (see [4]). Earlier versions
(back through Windows 7 to XP) *do* have 8-bit color available via the Console
API, but it's more cumbersome to access (especially from the `rust` realm)[5].

Pre-ANSI escape color may be too cumbersome to use, but the majority of
`pastel` has usefulness even if not displayed in color. "colorcheck" and "pick"
are obvious sub-commands which are unusable without some color support and so
both are disabled with an error message. "format" and "list" are modified to
only display non-colorized output. "paint", a judgement call about error vs
un-colorized, is left operational but without colorized output.

[1] [MS ~ Release Blog Post](https://devblogs.microsoft.com/commandline/24-bit-color-in-the-windows-console) @@ <https://archive.is/6UTBA>
[2] [Reddit ~ Win 10 ANSI Escapes](https://www.reddit.com/r/Windows10/comments/44czox/windows_10_v1511_adds_support_for_ansi_escape) @@ <https://archive.is/7l6tz>
[3] [MS TechNet Win 10 Versions](https://docs.microsoft.com/en-us/windows/release-information/) @@ <https://archive.is/sv3LN>
[4] [`ansi-term` ~ enable ANSI](https://github.com/rivy/rust.ansi-term/blob/ff7eba98d55ad609c7fcc8c7bb0859b37c7545cc/src/windows.rs#L25-L57)
[5] [rust-users ~ Windows color](https://users.rust-lang.org/t/colored-terminal-output/24604/12) @@ <https://web.archive.org/web/20190905231230/https://users.rust-lang.org/t/colored-terminal-output/24604/12>
```

I'd love to just implement 8-bit color, but, from [discussion](https://users.rust-lang.org/t/colored-terminal-output/24604/12), it looks like that would involve using [`termcolor`](https://docs.rs/termcolor). And I'm to new to the `rust` landscape to tackle that directly. I'm going to have to play around with some toy versions first just to understand how to use that crate.

So, barring that for the moment, this iteration does work for Windows 7 (and likely prior versions). There is one grumble... `main()` prints it's error messages surrounded with ANSI-color escapes. Since the color testing isn't done and added to the config structure until within `run()`, it's unavailable to `main()`. *If* it needs to be fixed, the refactor is a bit large, and I haven't seen a good, understandable example of a CLI written in rust that handles color from the `main()`. Any thoughts?