### PR TITLE
refactor distinct

### DIFF
--- a/src/cli/commands/distinct.rs
+++ b/src/cli/commands/distinct.rs
@@ -169,7 +169,6 @@ impl GenericCommand for DistinctCommand {
 
         let mut callback: Box<dyn FnMut(&IterationStatistics)> = if verbose_output {
             Box::new(|stats: &IterationStatistics| {
-                let brush_stderr = Brush::from_environment(Stream::Stderr);
                 print_iteration(&mut stderr_lock, &brush_stderr, stats).ok();
             })
         } else {

--- a/src/distinct.rs
+++ b/src/distinct.rs
@@ -247,7 +247,7 @@ pub fn distinct_colors(
     count: usize,
     distance_metric: DistanceMetric,
     fixed_colors: Vec<Color>,
-    mut callback: Box<dyn FnMut(&IterationStatistics)>,
+    callback: &mut dyn FnMut(&IterationStatistics),
 ) -> (Vec<Color>, DistanceResult) {
     assert!(count > 1);
     assert!(fixed_colors.len() <= count);
@@ -272,7 +272,7 @@ pub fn distinct_colors(
         },
     );
 
-    annealing.run(callback.as_mut());
+    annealing.run(callback);
 
     annealing.parameters.initial_temperature = 0.5;
     annealing.parameters.cooling_rate = 0.98;
@@ -280,7 +280,7 @@ pub fn distinct_colors(
     annealing.parameters.opt_target = OptimizationTarget::Min;
     annealing.parameters.opt_mode = OptimizationMode::Local;
 
-    let result = annealing.run(callback.as_mut());
+    let result = annealing.run(callback);
 
     (annealing.get_colors(), result)
 }


### PR DESCRIPTION
- refactor distinct sub-command into externally usable function, `distinct_colors()`

During testing, I ran into 32/64-bit differences in outcome and modified the tests to compensate.

I re-implemented the changes based on your fixed color implementation. (I had been using `invariant_colors` as the name when I was experimenting and left that in as a single commit ... easy to remove if you prefer `fixed_colors`).

To facilitate testing, I also went down the AppVeyor CI rabbit-hole for a couple of days and emerged with a generally flexible and functional configuration (including 32-bit and 64-bit, as well as, MSVC and GNU compilation).

I modified the Travis CI to include 32-bit compilation. I also saw that Windows compilation was now being included, but I marked them as possible failure and left the AppVeyor configuration commit since the Travis implementation is in "preview".

- ref: [AppVeyor CI build/test](https://ci.appveyor.com/project/rivy/rust-pastel/builds/27456809)
- ref: [Travis CI build/test](https://travis-ci.org/rivy/rust.pastel/builds/585881371)

I also ended up adding an EditorConfig file as a commit, just to stop my IDE from grumbling.

Let me know what you think. I'm happy to modify or drop any of the commits.