### PR TITLE
Add combinator parsing to parser.rs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,10 @@ matrix:
         - TARGET=aarch64-unknown-linux-gnu
         - CC_aarch64-unknown-linux-gnu=/usr/bin/aarch64-linux-gnu-gcc-4.8
         - CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc-4.8
-    - os: windows
-      rust: stable
-      env: TARGET=x86_64-pc-windows-msvc
+    # currently broken
+    # - os: windows
+    #   rust: stable
+    #   env: TARGET=x86_64-pc-windows-msvc
 
     # Minimum Rust supported channel.
     - os: linux

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +148,18 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lexical-core"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +176,21 @@ dependencies = [
 name = "memchr"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "nom"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lexical-core 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "num-traits"
@@ -183,6 +218,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "escargot 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xoshiro 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -295,8 +331,29 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -326,6 +383,11 @@ dependencies = [
  "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
@@ -390,6 +452,11 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "wasi"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
+"checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
 "checksum assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2dc477793bd82ec39799b6f6b3df64938532fdf2ab0d49ef817eac65856a5a1e"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
@@ -441,9 +509,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+"checksum lexical-core 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2304bccb228c4b020f3a4835d247df0a02a7c4686098d4167762cfbbe4c5cb14"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
+"checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+"checksum nom 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c618b63422da4401283884e6668d39f819a106ef51f5f59b81add00075da35ca"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
@@ -459,10 +530,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_xoshiro 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
+"checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
+"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
 "checksum serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "4b133a43a1ecd55d4086bd5b4dc6c1751c68b1bfbeba7a5040442022c7e7c02e"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
+"checksum static_assertions 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
@@ -472,6 +547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "approx"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,8 +63,34 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "autocfg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bstr"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -69,6 +100,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cast"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -92,8 +131,109 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "criterion-plot 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oorandom 11.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plotters 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tinytemplate 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bstr 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "either"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -129,9 +269,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "js-sys"
+version = "0.3.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -173,14 +345,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "memchr"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "memoffset"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "nom"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "nom"
@@ -201,6 +395,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hermit-abi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "oorandom"
+version = "11.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +424,7 @@ dependencies = [
  "assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "criterion 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "escargot 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -223,6 +432,17 @@ dependencies = [
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xoshiro 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "plotters"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -315,6 +535,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +565,14 @@ dependencies = [
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -341,6 +591,19 @@ dependencies = [
 [[package]]
 name = "ryu"
 version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -383,6 +646,11 @@ dependencies = [
  "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "sourcefile"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "static_assertions"
@@ -432,8 +700,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "treeline"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -457,9 +739,103 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "wasi"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bumpalo 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro-support 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wasm-bindgen-webidl"
+version = "0.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-webidl 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "weedle"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi"
@@ -486,6 +862,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,30 +877,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
 "checksum approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
 "checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
 "checksum assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2dc477793bd82ec39799b6f6b3df64938532fdf2ab0d49ef817eac65856a5a1e"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
+"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
+"checksum bstr 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "502ae1441a0a5adb8fbd38a5955a6416b9493e92b465de5e4a9bde6a539c2c48"
+"checksum bumpalo 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
+"checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
+"checksum cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+"checksum criterion 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1fc755679c12bda8e5523a71e4d654b6bf2e14bd838dfc48cde6559a05caf7d1"
+"checksum criterion-plot 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a01e15e0ea58e8234f96146b1f91fa9d0e4dd7a38da93ff7a75d42c0b9d3a545"
+"checksum crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+"checksum crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+"checksum crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
+"checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+"checksum csv 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
+"checksum csv-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+"checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum escargot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ceb9adbf9874d5d028b5e4c5739d22b71988252b25c9c98fe7cf9738bee84597"
 "checksum escargot 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "74cf96bec282dcdb07099f7e31d9fed323bca9435a09aba7b6d99b7617bca96d"
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
+"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum hermit-abi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "e2c55f143919fbc0bc77e427fe2d74cf23786d7c1875666f2fde3ac3c659bb67"
+"checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
+"checksum js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lexical-core 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2304bccb228c4b020f3a4835d247df0a02a7c4686098d4167762cfbbe4c5cb14"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+"checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
+"checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
 "checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+"checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum nom 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c618b63422da4401283884e6668d39f819a106ef51f5f59b81add00075da35ca"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
+"checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
+"checksum oorandom 11.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebcec7c9c2a95cacc7cd0ecb89d8a8454eca13906f6deb55258ffff0adeb9405"
 "checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+"checksum plotters 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "4e3bb8da247d27ae212529352020f3e5ee16e83c0c258061d27b08ab92675eeb"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum predicates 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53e09015b0d3f5a0ec2d4428f7559bb7b3fff341b4e159fedd1d57fac8b939ff"
 "checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
@@ -528,29 +937,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum rand_xoshiro 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
+"checksum rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
+"checksum rayon-core 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
+"checksum regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
+"checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+"checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
 "checksum serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "4b133a43a1ecd55d4086bd5b4dc6c1751c68b1bfbeba7a5040442022c7e7c02e"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
+"checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum static_assertions 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum tinytemplate 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "57a3c6667d3e65eb1bc3aed6fd14011c6cbc3a0665218ab7f5daf040b9ec371a"
 "checksum treeline 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+"checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
+"checksum wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "5205e9afdf42282b192e2310a5b463a6d1c1d774e30dc3c791ac37ab42d2616c"
+"checksum wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "11cdb95816290b525b32587d76419facd99662a07e59d3cdb560488a819d9a45"
+"checksum wasm-bindgen-macro 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "574094772ce6921576fb6f2e3f7497b8a76273b6db092be18fc48a082de09dc3"
+"checksum wasm-bindgen-macro-support 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "e85031354f25eaebe78bb7db1c3d86140312a911a106b2e29f9cc440ce3e7668"
+"checksum wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "f5e7e61fc929f4c0dddb748b102ebf9f632e2b8d739f2016542b4de2965a9601"
+"checksum wasm-bindgen-webidl 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "ef012a0d93fc0432df126a8eaf547b2dce25a8ce9212e1d3cbeef5c11157975d"
+"checksum web-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "aaf97caf6aa8c2b1dac90faf0db529d9d63c93846cca4911856f78a83cebf53b"
+"checksum weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,8 @@ approx = "0.3"
 assert_cmd = "0.11.1"
 escargot = "0.5.0"
 rand_xoshiro = "0.4.0"
+criterion = "0.3"
+
+[[bench]]
+name = "parse_color"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ lazy_static = "1.3.0"
 rand = "0.7"
 atty = "0.2"
 output_vt100 = "0.1"
+nom = "5"
 
 # binary-only dependencies (see https://github.com/rust-lang/cargo/issues/1982)
 regex = "1"

--- a/benches/parse_color.rs
+++ b/benches/parse_color.rs
@@ -1,0 +1,24 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use pastel::parser::parse_color;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("parse_hex", |b| {
+        b.iter(|| {
+            parse_color("#ff0077");
+        })
+    });
+    c.bench_function("parse_hex_short", |b| {
+        b.iter(|| {
+            parse_color("#f07");
+        })
+    });
+    c.bench_function("parse_rgb", |b| {
+        b.iter(|| {
+            parse_color("rgb(255, 125, 0)");
+        })
+    });
+    c.bench_function("parse_hsl", |b| b.iter(|| parse_color("hsl(280,20%,50%)")));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/cli/commands/io.rs
+++ b/src/cli/commands/io.rs
@@ -4,10 +4,10 @@ use clap::{ArgMatches, Values};
 
 use crate::colorpicker::{print_colorspectrum, run_external_colorpicker};
 use crate::config::Config;
-use crate::parser::parse_color;
 use crate::{PastelError, Result};
 
 use pastel::Color;
+use pastel::parser::parse_color;
 
 pub fn number_arg(matches: &ArgMatches, name: &str) -> Result<f64> {
     let value_str = matches.value_of(name).expect("required argument");

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -1,8 +1,8 @@
 use crate::commands::prelude::*;
 use crate::commands::sort::key_function;
-use crate::named::{NamedColor, NAMED_COLORS};
 
 use pastel::ansi::ToAnsiStyle;
+use pastel::named::{NamedColor, NAMED_COLORS};
 
 pub struct ListCommand;
 

--- a/src/cli/commands/paint.rs
+++ b/src/cli/commands/paint.rs
@@ -1,11 +1,11 @@
 use std::io::{self, Read};
 
 use crate::commands::prelude::*;
-use crate::parser::parse_color;
 
 use super::io::ColorArgIterator;
 
 use pastel::ansi::Style;
+use pastel::parser::parse_color;
 
 pub struct PaintCommand;
 

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -10,9 +10,7 @@ mod commands;
 mod config;
 mod error;
 mod hdcanvas;
-mod named;
 mod output;
-mod parser;
 mod utility;
 
 use commands::Command;

--- a/src/cli/parser.rs
+++ b/src/cli/parser.rs
@@ -202,21 +202,26 @@ pub fn parse_color(input: &str) -> Option<Color> {
         all_consuming(parse_gray),
         all_consuming(parse_lab),
         all_consuming(parse_named),
-    ))(input)
+    ))(input.trim())
     .ok()
     .map(|(_, c)| c)
 }
 
 #[test]
 fn parse_rgb_hex_syntax() {
+    assert_eq!(Some(rgb(255, 0, 153)), parse_color("f09"));
     assert_eq!(Some(rgb(255, 0, 153)), parse_color("#f09"));
     assert_eq!(Some(rgb(255, 0, 153)), parse_color("#F09"));
+
     assert_eq!(Some(rgb(255, 0, 153)), parse_color("#ff0099"));
     assert_eq!(Some(rgb(255, 0, 153)), parse_color("#FF0099"));
+    assert_eq!(Some(rgb(255, 0, 153)), parse_color("ff0099"));
 
     assert_eq!(Some(rgb(87, 166, 206)), parse_color("57A6CE"));
+    assert_eq!(Some(rgb(255, 0, 119)), parse_color("  #ff0077  "));
 
     assert_eq!(None, parse_color("#1"));
+    assert_eq!(None, parse_color("#12"));
     assert_eq!(None, parse_color("#12345"));
     assert_eq!(None, parse_color("#1234567"));
     assert_eq!(None, parse_color("#hh0033"));
@@ -230,6 +235,21 @@ fn parse_rgb_functional_syntax() {
     assert_eq!(Some(rgb(255, 0, 153)), parse_color("rgb( 255 , 0 , 153 )"));
     assert_eq!(Some(rgb(255, 0, 153)), parse_color("rgb(255, 0, 153.0)"));
     assert_eq!(Some(rgb(255, 0, 153)), parse_color("rgb(255 0 153)"));
+
+    assert_eq!(
+        Some(rgb(255, 8, 119)),
+        parse_color("  rgb( 255  ,  8  ,  119 )  ")
+    );
+
+    assert_eq!(Some(rgb(255, 0, 127)), parse_color("rgb(100%,0%,49.8%)"));
+    assert_eq!(Some(rgb(255, 0, 153)), parse_color("rgb(100%,0%,60%)"));
+    assert_eq!(Some(rgb(255, 0, 119)), parse_color("rgb(100%,0%,46.7%)"));
+    assert_eq!(Some(rgb(3, 54, 119)), parse_color("rgb(1%,21.2%,46.7%)"));
+    assert_eq!(Some(rgb(255, 0, 119)), parse_color("rgb(255 0 119)"));
+    assert_eq!(
+        Some(rgb(255, 0, 119)),
+        parse_color("rgb(    255      0      119)")
+    );
 
     assert_eq!(Some(rgb(255, 0, 153)), parse_color("rgb(100%,0%,60%)"));
     assert_eq!(Some(rgb(255, 0, 153)), parse_color("rgb(100%, 0%, 60%)"));
@@ -254,10 +274,21 @@ fn parse_rgb_functional_syntax() {
 
 #[test]
 fn parse_rgb_standalone_syntax() {
+    assert_eq!(
+        Some(rgb(255, 8, 119)),
+        parse_color("  rgb( 255  ,  8  ,  119 )  ")
+    );
+
     assert_eq!(rgb(255, 0, 153), parse_color("255,0,153").unwrap());
     assert_eq!(rgb(255, 0, 153), parse_color("255, 0, 153").unwrap());
+    assert_eq!(
+        rgb(255, 0, 153),
+        parse_color("  255  ,  0  ,  153   ").unwrap()
+    );
     assert_eq!(rgb(255, 0, 153), parse_color("255 0 153").unwrap());
     assert_eq!(rgb(255, 0, 153), parse_color("255 0 153.0").unwrap());
+
+    assert_eq!(Some(rgb(1, 2, 3)), parse_color("1,2,3"));
 }
 
 #[test]
@@ -330,7 +361,7 @@ fn parse_gray_syntax() {
 
     assert_eq!(Some(Color::graytone(0.32)), parse_color("gray(.32)"));
 
-    assert_eq!(Some(Color::graytone(0.41)), parse_color("gray(  0.41   )"));
+    assert_eq!(Some(Color::graytone(0.41)), parse_color("  gray(  0.41   ) "));
 
     assert_eq!(Some(Color::graytone(0.2)), parse_color("gray(20%)"));
     assert_eq!(Some(Color::black()), parse_color("gray(0%)"));

--- a/src/cli/parser.rs
+++ b/src/cli/parser.rs
@@ -1,6 +1,12 @@
-use lazy_static::lazy_static;
+use nom::branch::alt;
+use nom::bytes::complete::*;
+use nom::character::complete::*;
+use nom::combinator::*;
+use nom::error::ErrorKind;
+use nom::number::complete::double;
+use nom::Err;
+use nom::IResult;
 use pastel::Color;
-use regex::Regex;
 
 use crate::named::NAMED_COLORS;
 
@@ -8,399 +14,254 @@ fn hex_to_u8_unsafe(num: &str) -> u8 {
     u8::from_str_radix(num, 16).unwrap()
 }
 
-fn dec_to_u8(num: &str) -> Option<u8> {
-    u8::from_str_radix(num, 10).ok()
-}
-
-fn float_to_f64(num: &str) -> Option<f64> {
-    num.parse::<f64>().ok()
-}
-
 fn rgb(r: u8, g: u8, b: u8) -> Color {
     Color::from_rgb(r, g, b)
 }
 
-lazy_static! {
-    // #RRGGBB
-    pub static ref RE_HEX_RRGGBB: Regex = Regex::new(
-        r"(?x)
-            ^
-            \#?                # optional '#' character
-            ([[:xdigit:]]{2})  # two hexadecimal digits (red)
-            ([[:xdigit:]]{2})  # two hexadecimal digits (green)
-            ([[:xdigit:]]{2})  # two hexadecimal digits (blue)
-            $
-        ",
-    )
-    .unwrap();
-
-    // #RGB
-    pub static ref RE_HEX_RGB: Regex = Regex::new(
-        r"(?x)
-            ^
-            \#?             # optional '#' character
-            ([[:xdigit:]])  # one hexadecimal digit (red)
-            ([[:xdigit:]])  # one hexadecimal digit (green)
-            ([[:xdigit:]])  # one hexadecimal digit (blue)
-            $
-        ",
-    )
-    .unwrap();
-
-    // rgb(255,0,119)
-    pub static ref RE_RGB: Regex = Regex::new(
-        r"(?x)
-            ^
-            rgb\(
-                \s*
-                (\d{1,3})
-                \s*
-                ,
-                \s*
-                (\d{1,3})
-                \s*
-                ,
-                \s*
-                (\d{1,3})
-                \s*
-            \)
-            $
-        ",
-    )
-    .unwrap();
-
-    // rgb(255 0 119)
-    pub static ref RE_RGB_SPACE: Regex = Regex::new(
-        r"(?x)
-            ^
-            rgb\(
-                \s*
-                (\d{1,3})
-                \s+
-                (\d{1,3})
-                \s+
-                (\d{1,3})
-                \s*
-            \)
-            $
-        ",
-    )
-    .unwrap();
-
-    // rgb(100%,0%,46.7%)
-    pub static ref RE_RGB_PERCENT: Regex = Regex::new(
-        r"(?x)
-            ^
-            rgb\(
-                \s*
-                (\d+(?:\.\d+)?)%
-                \s*
-                ,
-                \s*
-                (\d+(?:\.\d+)?)%
-                \s*
-                ,
-                \s*
-                (\d+(?:\.\d+)?)%
-                \s*
-            \)
-            $
-        ",
-    )
-    .unwrap();
-
-    // RRRGGGBBB without the `rgb(...)` function: 255,0,119
-    pub static ref RE_RGB_NOFUNCTION: Regex = Regex::new(
-        r"(?x)
-            ^
-            (\d{1,3})
-            \s*
-            ,
-            \s*
-            (\d{1,3})
-            \s*
-            ,
-            \s*
-            (\d{1,3})
-            $
-        ",
-    )
-    .unwrap();
-
-    // hsl(280,35%,40$)
-    pub static ref RE_HSL: Regex = Regex::new(
-        r"(?x)
-            ^
-            hsl\(
-                \s*
-                (-?\d+(?:\.\d+)?)
-                (deg|°|grad|rad|turn)?
-                \s*
-                ,
-                \s*
-                (\d+(?:\.\d+)?)
-                %
-                \s*
-                ,
-                \s*
-                (\d+(?:\.\d+)?)
-                %
-                \s*
-            \)
-            $
-        ",
-    )
-    .unwrap();
-
-    // gray(0.2)
-    pub static ref RE_GRAY: Regex = Regex::new(
-        r"(?x)
-            ^
-            gray\(
-            \s*
-            (
-                    \d+(\.\d+)?   # 1 or 0.321
-                |
-                    \.\d+         # .23
-            )
-            \s*
-            \)
-        ",
-    )
-    .unwrap();
-
-    // gray(20%)
-    pub static ref RE_GRAY_PERCENT: Regex = Regex::new(
-        r"(?x)
-            ^
-            gray\(
-            \s*
-            (\d+(?:\.\d+)?)%
-            \s*
-            \)
-        ",
-    )
-    .unwrap();
-
-    // Lab(53.2,-35.4,-68.12,0.5)
-    pub static ref RE_LAB: Regex = Regex::new(
-    r"(?ix)
-        ^
-        (?:cie)?lab\(
-            \s*
-            (\d+(?:\.\d+)?) # L value
-            \s*
-            ,
-            \s*
-            (-?\d+(?:\.\d+)?) # A value
-            \s*
-            ,
-            \s*
-            (-?\d+(?:\.\d+)?) # B value
-            \s*
-            (?:
-            ,
-            \s*
-            (\d+(?:\.\d+)?)
-            \s*
-            )?
-        \)$
-    ")
-    .unwrap();
+fn comma_separated(input: &str) -> IResult<&str, &str> {
+    let (input, _) = space0(input)?;
+    let (input, _) = char(',')(input)?;
+    space0(input)
 }
 
-pub fn parse_color(color: &str) -> Option<Color> {
-    let color = color.trim();
+fn parse_separator(input: &str) -> IResult<&str, &str> {
+    alt((comma_separated, space1))(input)
+}
 
-    if let Some(caps) = RE_HEX_RRGGBB.captures(color) {
-        let r = hex_to_u8_unsafe(caps.get(1).unwrap().as_str());
-        let g = hex_to_u8_unsafe(caps.get(2).unwrap().as_str());
-        let b = hex_to_u8_unsafe(caps.get(3).unwrap().as_str());
+fn opt_hash_char(s: &str) -> IResult<&str, Option<char>> {
+    opt(char('#'))(s)
+}
 
-        return Some(rgb(r, g, b));
-    }
+fn parse_percentage(input: &str) -> IResult<&str, f64> {
+    let (input, percent) = double(input)?;
+    let (input, _) = char('%')(input)?;
+    Ok((input, percent / 100.))
+}
 
-    if let Some(caps) = RE_HEX_RGB.captures(color) {
-        let r = hex_to_u8_unsafe(caps.get(1).unwrap().as_str());
-        let g = hex_to_u8_unsafe(caps.get(2).unwrap().as_str());
-        let b = hex_to_u8_unsafe(caps.get(3).unwrap().as_str());
+fn parse_degrees(input: &str) -> IResult<&str, f64> {
+    let (input, d) = double(input)?;
+    let (input, _) = alt((tag("°"), tag("deg"), tag("")))(input)?;
+    Ok((input, d))
+}
 
-        let r = 16 * r + r;
-        let g = 16 * g + g;
-        let b = 16 * b + b;
+fn parse_rads(input: &str) -> IResult<&str, f64> {
+    let (input, rads) = double(input)?;
+    let (input, _) = tag("rad")(input)?;
+    Ok((input, rads * 180. / 3.14159))
+}
 
-        return Some(rgb(r, g, b));
-    }
+fn parse_grads(input: &str) -> IResult<&str, f64> {
+    let (input, grads) = double(input)?;
+    let (input, _) = tag("grad")(input)?;
+    Ok((input, grads * 360. / 400.))
+}
 
-    if let Some(caps) = RE_RGB.captures(color) {
-        let mr = dec_to_u8(caps.get(1).unwrap().as_str());
-        let mg = dec_to_u8(caps.get(2).unwrap().as_str());
-        let mb = dec_to_u8(caps.get(3).unwrap().as_str());
+fn parse_turns(input: &str) -> IResult<&str, f64> {
+    let (input, turns) = double(input)?;
+    let (input, _) = tag("turn")(input)?;
+    Ok((input, turns * 360.))
+}
 
-        match (mr, mg, mb) {
-            (Some(r), Some(g), Some(b)) => return Some(rgb(r, g, b)),
-            _ => {}
-        };
-    }
+fn parse_angle(input: &str) -> IResult<&str, f64> {
+    alt((parse_turns, parse_grads, parse_rads, parse_degrees))(input)
+}
 
-    if let Some(caps) = RE_RGB_SPACE.captures(color) {
-        let mr = dec_to_u8(caps.get(1).unwrap().as_str());
-        let mg = dec_to_u8(caps.get(2).unwrap().as_str());
-        let mb = dec_to_u8(caps.get(3).unwrap().as_str());
-
-        match (mr, mg, mb) {
-            (Some(r), Some(g), Some(b)) => return Some(rgb(r, g, b)),
-            _ => {}
-        };
-    }
-
-    if let Some(caps) = RE_RGB_PERCENT.captures(color) {
-        let pr = float_to_f64(caps.get(1).unwrap().as_str());
-        let pg = float_to_f64(caps.get(2).unwrap().as_str());
-        let pb = float_to_f64(caps.get(3).unwrap().as_str());
-
-        match (pr, pg, pb) {
-            (Some(pr), Some(pg), Some(pb)) => {
-                let r = pr / 100.0;
-                let g = pg / 100.0;
-                let b = pb / 100.0;
-                return Some(Color::from_rgb_float(r, g, b));
-            }
-            _ => {}
-        };
-    }
-
-    if let Some(caps) = RE_RGB_NOFUNCTION.captures(color) {
-        let mr = dec_to_u8(caps.get(1).unwrap().as_str());
-        let mg = dec_to_u8(caps.get(2).unwrap().as_str());
-        let mb = dec_to_u8(caps.get(3).unwrap().as_str());
-
-        match (mr, mg, mb) {
-            (Some(r), Some(g), Some(b)) => return Some(rgb(r, g, b)),
-            _ => {}
-        };
-    }
-
-    if let Some(caps) = RE_HSL.captures(color) {
-        let mh = float_to_f64(caps.get(1).unwrap().as_str());
-        let unit = match caps.get(2) {
-            Some(s) => s.as_str(),
-            None => "deg",
-        };
-        let ms = float_to_f64(caps.get(3).unwrap().as_str());
-        let ml = float_to_f64(caps.get(4).unwrap().as_str());
-
-        match (mh, ms, ml) {
-            (Some(h), Some(s), Some(l)) => {
-                let h = match unit {
-                    "°" | "deg" => h,
-                    "grad" => h * (18.0 / 20.0),
-                    "rad" => h.to_degrees(),
-                    "turn" => h * 360.0,
-                    _ => unimplemented!(),
-                };
-                let s = f64::from(s) / 100.0;
-                let l = f64::from(l) / 100.0;
-                return Some(Color::from_hsl(h, s, l));
-            }
-            _ => {}
-        };
-    }
-
-    if let Some(caps) = RE_GRAY.captures(color) {
-        if let Some(lightness) = float_to_f64(caps.get(1).unwrap().as_str()) {
-            return Some(Color::graytone(lightness));
+fn parse_hex(input: &str) -> IResult<&str, Color> {
+    let (input, _) = opt_hash_char(input)?;
+    let (input, hex_chars) = hex_digit1(input)?;
+    match hex_chars.len() {
+        6 => {
+            let r = hex_to_u8_unsafe(&hex_chars[0..2]);
+            let g = hex_to_u8_unsafe(&hex_chars[2..4]);
+            let b = hex_to_u8_unsafe(&hex_chars[4..6]);
+            Ok((input, rgb(r, g, b)))
         }
-    }
-
-    if let Some(caps) = RE_GRAY_PERCENT.captures(color) {
-        if let Some(lightness_percentage) = float_to_f64(caps.get(1).unwrap().as_str()) {
-            return Some(Color::graytone(lightness_percentage / 100.0));
+        3 => {
+            let r = hex_to_u8_unsafe(&hex_chars[0..1]);
+            let g = hex_to_u8_unsafe(&hex_chars[1..2]);
+            let b = hex_to_u8_unsafe(&hex_chars[2..3]);
+            let r = r * 16 + r;
+            let g = g * 16 + g;
+            let b = b * 16 + b;
+            Ok((input, rgb(r, g, b)))
         }
+        _ => Err(Err::Error((
+            "Expected hex string of 3 or 6 characters length",
+            ErrorKind::Many1,
+        ))),
     }
+}
 
-    if let Some(caps) = RE_LAB.captures(color) {
-        let ml = float_to_f64(caps.get(1).unwrap().as_str());
-        let ma = float_to_f64(caps.get(2).unwrap().as_str());
-        let mb = float_to_f64(caps.get(3).unwrap().as_str());
-        let malpha = match caps.get(4) {
-            Some(a) => float_to_f64(a.as_str()),
-            _ => Some(1.0),
-        };
+fn parse_numeric_rgb(input: &str) -> IResult<&str, Color> {
+    let (input, prefixed) = opt(tag("rgb("))(input)?;
+    let is_prefixed = prefixed.is_some();
+    let (input, _) = space0(input)?;
+    let (input, r) = double(input)?;
+    let (input, _) = parse_separator(input)?;
+    let (input, g) = double(input)?;
+    let (input, _) = parse_separator(input)?;
+    let (input, b) = double(input)?;
+    let (input, _) = space0(input)?;
+    let (input, _) = cond(is_prefixed, char(')'))(input)?;
 
-        match (ml, ma, mb, malpha) {
-            (Some(l), Some(a), Some(b), Some(alpha)) => {
-                let l = f64::from(l);
-                let a = f64::from(a);
-                let b = f64::from(b);
-                let alpha = f64::from(alpha);
+    let r = r / 255.;
+    let g = g / 255.;
+    let b = b / 255.;
+    let c = Color::from_rgb_float(r, g, b);
 
-                return Some(Color::from_lab(l, a, b, alpha));
-            }
-            _ => {}
-        }
+    Ok((input, c))
+}
+
+fn parse_percentage_rgb(input: &str) -> IResult<&str, Color> {
+    let (input, prefixed) = opt(tag("rgb("))(input)?;
+    let is_prefixed = prefixed.is_some();
+    let (input, _) = space0(input)?;
+    let (input, r) = parse_percentage(input)?;
+    let (input, _) = parse_separator(input)?;
+    let (input, g) = parse_percentage(input)?;
+    let (input, _) = parse_separator(input)?;
+    let (input, b) = parse_percentage(input)?;
+    let (input, _) = space0(input)?;
+    let (input, _) = cond(is_prefixed, char(')'))(input)?;
+
+    let c = Color::from_rgb_float(r, g, b);
+
+    Ok((input, c))
+}
+
+fn parse_hsl(input: &str) -> IResult<&str, Color> {
+    let (input, _) = tag("hsl(")(input)?;
+    let (input, _) = space0(input)?;
+    let (input, h) = parse_angle(input)?;
+    let (input, _) = parse_separator(input)?;
+    let (input, s) = parse_percentage(input)?;
+    let (input, _) = parse_separator(input)?;
+    let (input, l) = parse_percentage(input)?;
+    let (input, _) = space0(input)?;
+    let (input, _) = char(')')(input)?;
+
+    let c = Color::from_hsl(h, s, l);
+
+    Ok((input, c))
+}
+
+fn parse_gray(input: &str) -> IResult<&str, Color> {
+    let (input, _) = tag("gray(")(input)?;
+    let (input, _) = space0(input)?;
+    let (input, g) = verify(alt((parse_percentage, double)), |&d| d >= 0.)(input)?;
+    let (input, _) = space0(input)?;
+    let (input, _) = char(')')(input)?;
+
+    let c = Color::from_rgb_float(g, g, g);
+
+    Ok((input, c))
+}
+
+fn parse_lab(input: &str) -> IResult<&str, Color> {
+    let (input, _) = opt(tag_no_case("cie"))(input)?;
+    let (input, _) = tag_no_case("lab(")(input)?;
+    let (input, _) = space0(input)?;
+    let (input, l) = double(input)?;
+    let (input, _) = parse_separator(input)?;
+    let (input, a) = double(input)?;
+    let (input, _) = parse_separator(input)?;
+    let (input, b) = double(input)?;
+    let (input, alpha) = opt(|input: &str| {
+        let (input, _) = parse_separator(input)?;
+        double(input)
+    })(input)?;
+    let (input, _) = space0(input)?;
+    let (input, _) = char(')')(input)?;
+
+    let c = Color::from_lab(l, a, b, alpha.unwrap_or(1.0));
+
+    Ok((input, c))
+}
+
+fn parse_named(input: &str) -> IResult<&str, Color> {
+    let (input, color) = all_consuming(alpha1)(input)?;
+    let nc = NAMED_COLORS
+        .iter()
+        .find(|nc| color.to_lowercase() == nc.name);
+
+    match nc {
+        None => Err(Err::Error((
+            "Couldn't find matching named color",
+            ErrorKind::Alpha,
+        ))),
+        Some(nc) => Ok((input, nc.color.clone())),
     }
+}
 
-    for nc in NAMED_COLORS.iter() {
-        if color.to_lowercase() == nc.name {
-            return Some(nc.color.clone());
-        }
-    }
-
-    None
+pub fn parse_color(input: &str) -> Option<Color> {
+    alt((
+        all_consuming(parse_hex),
+        all_consuming(parse_numeric_rgb),
+        all_consuming(parse_percentage_rgb),
+        all_consuming(parse_hsl),
+        all_consuming(parse_gray),
+        all_consuming(parse_lab),
+        all_consuming(parse_named),
+    ))(input)
+    .ok()
+    .map(|(_, c)| c)
 }
 
 #[test]
-fn parse_hex_rrggbb() {
-    assert_eq!(Some(rgb(255, 0, 119)), parse_color("#ff0077"));
-    assert_eq!(Some(rgb(255, 0, 119)), parse_color("#FF0077"));
-    assert_eq!(Some(rgb(255, 0, 119)), parse_color("ff0077"));
+fn parse_rgb_hex_syntax() {
+    assert_eq!(Some(rgb(255, 0, 153)), parse_color("#f09"));
+    assert_eq!(Some(rgb(255, 0, 153)), parse_color("#F09"));
+    assert_eq!(Some(rgb(255, 0, 153)), parse_color("#ff0099"));
+    assert_eq!(Some(rgb(255, 0, 153)), parse_color("#FF0099"));
+
     assert_eq!(Some(rgb(87, 166, 206)), parse_color("57A6CE"));
-    assert_eq!(Some(rgb(255, 0, 119)), parse_color("  #ff0077  "));
 
     assert_eq!(None, parse_color("#1"));
     assert_eq!(None, parse_color("#12345"));
     assert_eq!(None, parse_color("#1234567"));
     assert_eq!(None, parse_color("#hh0033"));
-}
-
-#[test]
-fn parse_hex_rgb() {
-    assert_eq!(Some(rgb(255, 0, 119)), parse_color("#f07"));
-    assert_eq!(Some(rgb(255, 0, 119)), parse_color("#F07"));
-    assert_eq!(Some(rgb(255, 0, 119)), parse_color("f07"));
-
     assert_eq!(None, parse_color("#h03"));
 }
 
 #[test]
-fn parse_rgb() {
-    assert_eq!(Some(rgb(255, 0, 119)), parse_color("rgb(255,0,119)"));
-    assert_eq!(
-        Some(rgb(255, 8, 119)),
-        parse_color("  rgb( 255  ,  8  ,  119 )  ")
-    );
-    assert_eq!(Some(rgb(255, 0, 119)), parse_color("255,0,119"));
-    assert_eq!(Some(rgb(255, 0, 119)), parse_color("  255  ,  0  ,  119  "));
-    assert_eq!(Some(rgb(1, 2, 3)), parse_color("1,2,3"));
-    assert_eq!(Some(rgb(255, 0, 127)), parse_color("rgb(100%,0%,49.8%)"));
-    assert_eq!(Some(rgb(255, 0, 153)), parse_color("rgb(100%,0%,60%)"));
-    assert_eq!(Some(rgb(255, 0, 119)), parse_color("rgb(100%,0%,46.7%)"));
-    assert_eq!(Some(rgb(3, 54, 119)), parse_color("rgb(1%,21.2%,46.7%)"));
-    assert_eq!(Some(rgb(255, 0, 119)), parse_color("rgb(255 0 119)"));
-    assert_eq!(Some(rgb(255, 0, 119)), parse_color("rgb(    255      0      119)"));
+fn parse_rgb_functional_syntax() {
+    assert_eq!(Some(rgb(255, 0, 153)), parse_color("rgb(255,0,153)"));
+    assert_eq!(Some(rgb(255, 0, 153)), parse_color("rgb(255, 0, 153)"));
+    assert_eq!(Some(rgb(255, 0, 153)), parse_color("rgb( 255 , 0 , 153 )"));
+    assert_eq!(Some(rgb(255, 0, 153)), parse_color("rgb(255, 0, 153.0)"));
+    assert_eq!(Some(rgb(255, 0, 153)), parse_color("rgb(255 0 153)"));
 
-    assert_eq!(None, parse_color("rgb(256,0,0)"));
+    assert_eq!(Some(rgb(255, 0, 153)), parse_color("rgb(100%,0%,60%)"));
+    assert_eq!(Some(rgb(255, 0, 153)), parse_color("rgb(100%, 0%, 60%)"));
+    assert_eq!(
+        Some(rgb(255, 0, 153)),
+        parse_color("rgb( 100% , 0% , 60% )")
+    );
+    assert_eq!(Some(rgb(255, 0, 153)), parse_color("rgb(100% 0% 60%)"));
+
+    assert_eq!(Some(rgb(100, 5, 1)), parse_color("rgb(1e2, .5e1, .5e0)"));
+    assert_eq!(Some(rgb(140, 0, 153)), parse_color("rgb(55% 0% 60%)"));
+    assert_eq!(Some(rgb(142, 0, 153)), parse_color("rgb(55.5% 0% 60%)"));
+    assert_eq!(Some(rgb(255, 0, 0)), parse_color("rgb(256,0,0)"));
+    assert_eq!(Some(rgb(255, 255, 0)), parse_color("rgb(100%,100%,-45%)"));
+
     assert_eq!(None, parse_color("rgb(255,0)"));
     assert_eq!(None, parse_color("rgb(255,0,0"));
     assert_eq!(None, parse_color("rgb (256,0,0)"));
     assert_eq!(None, parse_color("rgb(100%,0,0)"));
-    assert_eq!(None, parse_color("rgb(100%,100%,-45%)"));
     assert_eq!(None, parse_color("rgb(2550119)"));
 }
 
 #[test]
-fn parse_hsl() {
+fn parse_rgb_standalone_syntax() {
+    assert_eq!(rgb(255, 0, 153), parse_color("255,0,153").unwrap());
+    assert_eq!(rgb(255, 0, 153), parse_color("255, 0, 153").unwrap());
+    assert_eq!(rgb(255, 0, 153), parse_color("255 0 153").unwrap());
+    assert_eq!(rgb(255, 0, 153), parse_color("255 0 153.0").unwrap());
+}
+
+#[test]
+fn parse_hsl_syntax() {
     assert_eq!(
         Some(Color::from_hsl(280.0, 0.2, 0.5)),
         parse_color("hsl(280,20%,50%)")
@@ -426,7 +287,7 @@ fn parse_hsl() {
         Some(Color::from_hsl(-140.0, 0.2, 0.5)),
         parse_color("hsl(-140°,20%,50%)")
     );
-    
+
     assert_eq!(
         Some(Color::from_hsl(90.0, 0.2, 0.5)),
         parse_color("hsl(100grad,20%,50%)")
@@ -459,7 +320,7 @@ fn parse_hsl() {
 }
 
 #[test]
-fn parse_gray() {
+fn parse_gray_syntax() {
     assert_eq!(Some(Color::graytone(0.2)), parse_color("gray(0.2)"));
     assert_eq!(Some(Color::black()), parse_color("gray(0.0)"));
     assert_eq!(Some(Color::black()), parse_color("gray(0)"));
@@ -469,10 +330,7 @@ fn parse_gray() {
 
     assert_eq!(Some(Color::graytone(0.32)), parse_color("gray(.32)"));
 
-    assert_eq!(
-        Some(Color::graytone(0.41)),
-        parse_color("  gray(  0.41   ) ")
-    );
+    assert_eq!(Some(Color::graytone(0.41)), parse_color("gray(  0.41   )"));
 
     assert_eq!(Some(Color::graytone(0.2)), parse_color("gray(20%)"));
     assert_eq!(Some(Color::black()), parse_color("gray(0%)"));
@@ -480,14 +338,13 @@ fn parse_gray() {
     assert_eq!(Some(Color::white()), parse_color("gray(100%)"));
     assert_eq!(Some(Color::graytone(0.5)), parse_color("gray(50%)"));
 
-    assert_eq!(None, parse_color("gray(1.)"));
     assert_eq!(None, parse_color("gray(-1)"));
     assert_eq!(None, parse_color("gray(-1%)"));
     assert_eq!(None, parse_color("gray(-4.%)"));
 }
 
 #[test]
-fn parse_lab() {
+fn parse_lab_syntax() {
     assert_eq!(
         Some(Color::from_lab(12.43, -35.5, 43.4, 1.0)),
         parse_color("Lab(12.43,-35.5,43.4)")
@@ -523,7 +380,7 @@ fn parse_lab() {
 }
 
 #[test]
-fn parse_predefined_name() {
+fn parse_named_syntax() {
     assert_eq!(Some(Color::black()), parse_color("black"));
     assert_eq!(Some(Color::blue()), parse_color("blue"));
     assert_eq!(Some(Color::blue()), parse_color("Blue"));

--- a/src/cli/utility.rs
+++ b/src/cli/utility.rs
@@ -1,6 +1,5 @@
 use pastel::Color;
-
-use crate::named::{NamedColor, NAMED_COLORS};
+use pastel::named::{NamedColor, NAMED_COLORS};
 
 /// Returns a list of named colors, sorted by the perceived distance to the given color
 pub fn similar_colors(color: &Color) -> Vec<&NamedColor> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@ pub mod colorspace;
 pub mod delta_e;
 pub mod distinct;
 mod helper;
+pub mod named;
+pub mod parser;
 pub mod random;
 mod types;
 

--- a/src/named.rs
+++ b/src/named.rs
@@ -1,6 +1,6 @@
 use lazy_static::lazy_static;
 
-use pastel::Color;
+use crate::Color;
 
 #[derive(Debug, Clone)]
 pub struct NamedColor {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,8 +6,8 @@ use nom::error::ErrorKind;
 use nom::number::complete::double;
 use nom::Err;
 use nom::IResult;
-use pastel::Color;
 
+use crate::Color;
 use crate::named::NAMED_COLORS;
 
 fn hex_to_u8_unsafe(num: &str) -> u8 {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -313,6 +313,10 @@ fn parse_hsl_syntax() {
         Some(Color::from_hsl(280.0, 0.2, 0.5)),
         parse_color("hsl(  280 , 20% , 50%)")
     );
+    assert_eq!(
+        Some(Color::from_hsl(270.0, 0.6, 0.7)),
+        parse_color("hsl(270 60% 70%)")
+    );
 
     assert_eq!(
         Some(Color::from_hsl(-140.0, 0.2, 0.5)),


### PR DESCRIPTION
Relates to #12 
This PR adds combinator-based parsing using [nom](https://github.com/Geal/nom).

This allows the code to uniformly handle numerics (percentages, decimals, integers), and can also eventually provide error output in case of parser failure (not implemented yet).

I haven't had a chance to benchmark the differences between the parsers yet.