### PR TITLE
Allow drawn text to be colored based on pixels that are in that location

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -281,17 +281,17 @@ impl Brush {
 
     pub fn paint<S>(self, text: S, style: impl Into<Style>) -> String
     where
-        S: AsRef<str>,
+        S: std::fmt::Display,
     {
         if let Some(ansi_mode) = self.mode {
             format!(
                 "{begin}{text}{end}",
                 begin = style.into().escape_sequence(ansi_mode),
-                text = text.as_ref(),
+                text = text,
                 end = "\x1b[0m"
             )
         } else {
-            text.as_ref().into()
+            format!("{}", text)
         }
     }
 }

--- a/src/cli/hdcanvas.rs
+++ b/src/cli/hdcanvas.rs
@@ -78,13 +78,14 @@ impl Canvas {
                     let p_top = self.pixel(2 * i_div_2, j);
                     let p_bottom = self.pixel(2 * i_div_2 + 1, j);
 
-                    let mut style;
+                    let mut style = Style::default();
 
-                    if let (Some(fg), Some(bg)) = (p_top, p_bottom) {
-                        style = fg.ansi_style();
+                    if let Some(fg) = p_top {
+                        style.foreground(fg);
+                    }
+
+                    if let Some(bg) = p_bottom {
                         style.on(bg);
-                    } else {
-                        style = Style::default();
                     }
 
                     write!(out, "{}", self.brush.paint(c, style))?;

--- a/src/cli/hdcanvas.rs
+++ b/src/cli/hdcanvas.rs
@@ -71,6 +71,12 @@ impl Canvas {
         }
     }
 
+    pub fn draw_colored_text(&mut self, row: usize, col: usize, text: &str, fg: &Color, bg: &Color) {
+        self.draw_text(row, col, text);
+        self.draw_rect(row, col, 1, text.len(), fg);
+        self.draw_rect(row + 1, col, 1, text.len(), bg);
+    }
+
     pub fn print(&self, out: &mut dyn Write) -> Result<()> {
         for i_div_2 in 0..self.height / 2 {
             for j in 0..self.width {

--- a/src/cli/hdcanvas.rs
+++ b/src/cli/hdcanvas.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use pastel::ansi::{Brush, ToAnsiStyle};
+use pastel::ansi::{Brush, Style, ToAnsiStyle};
 use pastel::Color;
 
 use crate::Result;
@@ -75,7 +75,19 @@ impl Canvas {
         for i_div_2 in 0..self.height / 2 {
             for j in 0..self.width {
                 if let Some(c) = self.char(i_div_2, j) {
-                    write!(out, "{}", c)?;
+                    let p_top = self.pixel(2 * i_div_2, j);
+                    let p_bottom = self.pixel(2 * i_div_2 + 1, j);
+
+                    let mut style;
+
+                    if let (Some(fg), Some(bg)) = (p_top, p_bottom) {
+                        style = fg.ansi_style();
+                        style.on(bg);
+                    } else {
+                        style = Style::default();
+                    }
+
+                    write!(out, "{}", self.brush.paint(c, style))?;
                 } else {
                     let p_top = self.pixel(2 * i_div_2, j);
                     let p_bottom = self.pixel(2 * i_div_2 + 1, j);


### PR DESCRIPTION
Text takes up two "rows" of pixels in the hdcanvas. We could use this to add colored drawn text and treat the first row as the foreground and the second as the background.

As an example usage (not added in this PR):
![image](https://user-images.githubusercontent.com/9531780/67429209-afdaa500-f5ad-11e9-9d22-c7d952da3701.png)
