### PR TITLE
Add new escaped ANSI formats

### DIFF
--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -206,13 +206,16 @@ pub fn build_cli() -> App<'static, 'static> {
                   pastel random -n 20 | pastel format rgb")
                 .arg(
                     Arg::with_name("type")
-                        .help("Output format type")
+                        .help("Output format type. Note that the 'ansi-*-escaped' formats print \
+                               ansi escape sequences to the terminal that will not be visible \
+                               unless something else is printed in addition.")
                         .possible_values(&["rgb", "rgb-float", "hex",
                                            "hsl", "hsl-hue", "hsl-saturation", "hsl-lightness",
                                            "lch", "lch-lightness", "lch-chroma", "lch-hue",
                                            "lab", "lab-a", "lab-b",
                                            "luminance", "brightness",
                                            "ansi-8bit", "ansi-24bit",
+                                           "ansi-8bit-escaped", "ansi-24bit-escaped",
                                            "name"])
                         .case_insensitive(true)
                         .default_value("hex")

--- a/src/cli/commands/format.rs
+++ b/src/cli/commands/format.rs
@@ -17,6 +17,10 @@ impl ColorCommand for FormatCommand {
         let format_type = matches.value_of("type").expect("required argument");
         let format_type = format_type.to_lowercase();
 
+        let replace_escape = |code: &str| {
+            code.replace("\x1b", "\\x1b")
+        };
+
         let output = match format_type.as_ref() {
             "rgb" => color.to_rgb_string(Format::Spaces),
             "rgb-float" => color.to_rgb_float_string(Format::Spaces),
@@ -34,8 +38,10 @@ impl ColorCommand for FormatCommand {
             "lab-b" => format!("{:.2}", color.to_lab().b),
             "luminance" => format!("{:.3}", color.luminance()),
             "brightness" => format!("{:.3}", color.brightness()),
-            "ansi-8bit" => color.to_ansi_sequence(Mode::Ansi8Bit),
-            "ansi-24bit" => color.to_ansi_sequence(Mode::TrueColor),
+            "ansi-8bit" => replace_escape(&color.to_ansi_sequence(Mode::Ansi8Bit)),
+            "ansi-24bit" => replace_escape(&color.to_ansi_sequence(Mode::TrueColor)),
+            "ansi-8bit-escapecode" => color.to_ansi_sequence(Mode::Ansi8Bit),
+            "ansi-24bit-escapecode" => color.to_ansi_sequence(Mode::TrueColor),
             "name" => similar_colors(color)[0].name.to_owned(),
             &_ => {
                 unreachable!("Unknown format type");
@@ -43,7 +49,7 @@ impl ColorCommand for FormatCommand {
         };
 
         let write_colored_line = match format_type.as_ref() {
-            "ansi-8bit" | "ansi-24bit" => false,
+            "ansi-8bit-escapecode" | "ansi-24bit-escapecode" => false,
             _ => true,
         };
 


### PR DESCRIPTION
This changes the existing `ansi-8bit` and `ansi-24bit` formats to print out an escaped ANSI sequence that a user can see in the terminal output:

```
❯ pastel format ansi-8bit 556270 4ecdc4 c7f484 ff6b6b c44d58      
\x1b[38;5;59m
\x1b[38;5;44m
\x1b[38;5;192m
\x1b[38;5;203m
\x1b[38;5;131m

❯ pastel format ansi-24bit 556270 4ecdc4 c7f484 ff6b6b c44d58
\x1b[38;2;85;98;112m
\x1b[38;2;78;205;196m
\x1b[38;2;199;244;132m
\x1b[38;2;255;107;107m
\x1b[38;2;196;77;88m
```

This is a breaking change. The existing formats are now available as `ansi-8bit-escapecode` and `ansi-24bit-escapecode`.

This closes #113