### PR TITLE
Add GHA CICD

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -21,15 +21,6 @@ jobs:
           - { os: windows-latest }
     steps:
     - uses: actions/checkout@v1
-    - name: Initialize workflow variables
-      id: vars
-      shell: bash
-      run: |
-        # 'windows-latest' `cargo fmt` is bugged for this project (see reasons @ GH:rust-lang/rustfmt #3324, #3590, #3688 ; waiting for repair)
-        JOB_DO_FORMAT_TESTING="true"
-        case ${{ matrix.job.os }} in windows-latest) unset JOB_DO_FORMAT_TESTING ;; esac;
-        echo set-output name=JOB_DO_FORMAT_TESTING::${JOB_DO_FORMAT_TESTING:-<empty>/false}
-        echo ::set-output name=JOB_DO_FORMAT_TESTING::${JOB_DO_FORMAT_TESTING}
     - name: Install `rust` toolchain
       uses: actions-rs/toolchain@v1
       with:
@@ -38,7 +29,6 @@ jobs:
         profile: minimal # minimal component installation (ie, no documentation)
         components: rustfmt, clippy
     - name: "`fmt` testing"
-      if: steps.vars.outputs.JOB_DO_FORMAT_TESTING
       uses: actions-rs/cargo@v1
       with:
         command: fmt

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -30,12 +30,6 @@ jobs:
         case ${{ matrix.job.os }} in windows-latest) unset JOB_DO_FORMAT_TESTING ;; esac;
         echo set-output name=JOB_DO_FORMAT_TESTING::${JOB_DO_FORMAT_TESTING:-<empty>/false}
         echo ::set-output name=JOB_DO_FORMAT_TESTING::${JOB_DO_FORMAT_TESTING}
-        # target-specific options
-        # * CARGO_FEATURES_OPTION
-        CARGO_FEATURES_OPTION='' ;
-        if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
-        echo set-output name=CARGO_FEATURES_OPTION::${CARGO_FEATURES_OPTION}
-        echo ::set-output name=CARGO_FEATURES_OPTION::${CARGO_FEATURES_OPTION}
     - name: Install `rust` toolchain
       uses: actions-rs/toolchain@v1
       with:
@@ -54,7 +48,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} -- -D warnings
+        args: ${{ matrix.job.cargo-options }} -- -D warnings
 
   min_version:
     name: MinSRV # Minimum supported rust version
@@ -180,11 +174,6 @@ jobs:
         echo set-output name=DPKG_NAME::${DPKG_NAME}
         echo ::set-output name=DPKG_NAME::${DPKG_NAME}
         # target-specific options
-        # * CARGO_FEATURES_OPTION
-        CARGO_FEATURES_OPTION='' ;
-        if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
-        echo set-output name=CARGO_FEATURES_OPTION::${CARGO_FEATURES_OPTION}
-        echo ::set-output name=CARGO_FEATURES_OPTION::${CARGO_FEATURES_OPTION}
         # * CARGO_USE_CROSS (truthy)
         CARGO_USE_CROSS='true' ; case '${{ matrix.job.use-cross }}' in ''|0|f|false|n|no) unset CARGO_USE_CROSS ;; esac;
         echo set-output name=CARGO_USE_CROSS::${CARGO_USE_CROSS:-<empty>/false}
@@ -230,13 +219,13 @@ jobs:
       with:
         use-cross: ${{ steps.vars.outputs.CARGO_USE_CROSS }}
         command: build
-        args: --release --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
+        args: --release --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }}
     - name: Test
       uses: actions-rs/cargo@v1
       with:
         use-cross: ${{ steps.vars.outputs.CARGO_USE_CROSS }}
         command: test
-        args: --target=${{ matrix.job.target }} ${{ steps.vars.outputs.CARGO_TEST_OPTIONS}} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
+        args: --target=${{ matrix.job.target }} ${{ steps.vars.outputs.CARGO_TEST_OPTIONS}} ${{ matrix.job.cargo-options }}
     - name: Archive executable artifacts
       uses: actions/upload-artifact@master
       with:
@@ -311,11 +300,6 @@ jobs:
         echo set-output name=TOOLCHAIN::${TOOLCHAIN}
         echo ::set-output name=TOOLCHAIN::${TOOLCHAIN}
         # target-specific options
-        # * CARGO_FEATURES_OPTION
-        CARGO_FEATURES_OPTION='--all-features' ;  ## default to '--all-features' for code coverage
-        if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
-        echo set-output name=CARGO_FEATURES_OPTION::${CARGO_FEATURES_OPTION}
-        echo ::set-output name=CARGO_FEATURES_OPTION::${CARGO_FEATURES_OPTION}
         # * CODECOV_FLAGS
         CODECOV_FLAGS=$( echo "${{ matrix.job.os }}" | sed 's/[^[:alnum:]]/_/g' )
         echo set-output name=CODECOV_FLAGS::${CODECOV_FLAGS}
@@ -330,7 +314,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: {{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --no-fail-fast
+        args: --no-fail-fast
       env:
         CARGO_INCREMENTAL: '0'
         RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -44,9 +44,7 @@ jobs:
           - { os: macos-latest   , target: x86_64-apple-darwin         }
           - { os: windows-latest , target: i686-pc-windows-gnu         }
           - { os: windows-latest , target: i686-pc-windows-msvc        }
-          - { os: windows-latest , target: x86_64-pc-windows-gnu , toolchain: nightly-x86_64-pc-windows-gnu }  ## ! maint: [rivy; due 2020-21-03] disable/remove when rust beta >= v1.43.0 is available (~mid-March) ;; [rivy; 2020-01-21] may break due to rust bug; follow possible solution from GH:rust-lang/rust#47048 (refs: GH:rust-lang/rust#47048 , GH:rust-lang/rust#53454 , GH:bike-barn/hermit#172)
-          # - { os: windows-latest , target: x86_64-pc-windows-gnu , toolchain: beta-x86_64-pc-windows-gnu }  ## ! maint: [rivy; due 2020-21-03; due 2020-01-05] enable when rust beta >= v1.43.0 is available (~mid-March); disable when rust stable >= 1.43.0 is available (~early-May)
-          # - { os: windows-latest , target: x86_64-pc-windows-gnu       }  ## note: requires rust >= 1.43.0 to link correctly # ! maint: [rivy; due 2020-01-05] enable when rust stable >= 1.43.0 is available
+          - { os: windows-latest , target: x86_64-pc-windows-gnu       }  ## note: requires rust >= 1.43.0 to link correctly
           - { os: windows-latest , target: x86_64-pc-windows-msvc      }
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -9,37 +9,6 @@ env:
 on: [push, pull_request]
 
 jobs:
-  style:
-    name: Style
-    runs-on: ${{ matrix.job.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        job:
-          - { os: ubuntu-latest }
-          - { os: macos-latest }
-          - { os: windows-latest }
-    steps:
-    - uses: actions/checkout@v1
-    - name: Install `rust` toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-        profile: minimal # minimal component installation (ie, no documentation)
-        components: rustfmt, clippy
-    - name: "`fmt` testing"
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
-    - name: "`clippy` testing"
-      if: success() || failure() # run regardless of prior step ("`fmt` testing") success/failure
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: ${{ matrix.job.cargo-options }} -- -D warnings
-
   min_version:
     name: MinSRV # Minimum supported rust version
     runs-on: ubuntu-latest

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -1,0 +1,307 @@
+name: CICD
+
+# spell-checker:ignore (acronyms) CICD MSVC musl
+# spell-checker:ignore (names) CodeCOV MacOS MinGW Peltoche rivy sharkdp
+# spell-checker:ignore (jargon) SHAs softprops toolchain
+# spell-checker:ignore (shell/tools) choco clippy dmake dpkg esac fakeroot gmake halium libssl mkdir nullglob popd printf pushd rustc rustfmt rustup shopt
+# spell-checker:ignore (misc) gnueabihf issuecomment maint onexitbegin onexitend uutils
+
+env:
+  PROJECT_NAME: pastel
+  PROJECT_DESC: "A command-line tool to generate, analyze, convert and manipulate colors"
+  PROJECT_AUTH: "sharkdp"
+  RUST_MIN_SRV: "1.35.0"
+
+on: [push, pull_request]
+
+jobs:
+  style:
+    name: Style
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - { os: ubuntu-latest }
+          - { os: macos-latest }
+          - { os: windows-latest }
+    steps:
+    - uses: actions/checkout@v1
+    - name: Initialize workflow variables
+      id: vars
+      shell: bash
+      run: |
+        # 'windows-latest' `cargo fmt` is bugged for this project (see reasons @ GH:rust-lang/rustfmt #3324, #3590, #3688 ; waiting for repair)
+        JOB_DO_FORMAT_TESTING="true"
+        case ${{ matrix.job.os }} in windows-latest) unset JOB_DO_FORMAT_TESTING ;; esac;
+        echo set-output name=JOB_DO_FORMAT_TESTING::${JOB_DO_FORMAT_TESTING:-<empty>/false}
+        echo ::set-output name=JOB_DO_FORMAT_TESTING::${JOB_DO_FORMAT_TESTING}
+        # target-specific options
+        # * CARGO_FEATURES_OPTION
+        CARGO_FEATURES_OPTION='' ;
+        if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
+        echo set-output name=CARGO_FEATURES_OPTION::${CARGO_FEATURES_OPTION}
+        echo ::set-output name=CARGO_FEATURES_OPTION::${CARGO_FEATURES_OPTION}
+    - name: Install `rust` toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+        profile: minimal # minimal component installation (ie, no documentation)
+        components: rustfmt, clippy
+    - name: "`fmt` testing"
+      if: steps.vars.outputs.JOB_DO_FORMAT_TESTING
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check
+    - name: "`clippy` testing"
+      if: success() || failure() # run regardless of prior step ("`fmt` testing") success/failure
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} -- -D warnings
+
+  min_version:
+    name: MinSRV # Minimum supported rust version
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install `rust` toolchain (v${{ env.RUST_MIN_SRV }})
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ env.RUST_MIN_SRV }}
+        default: true
+        profile: minimal # minimal component installation (ie, no documentation)
+    - name: Test
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+
+  build:
+    name: Build
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          # { os, target, cargo-options, features, use-cross, toolchain }
+          - { os: ubuntu-latest  , target: arm-unknown-linux-gnueabihf , use-cross: use-cross }
+          - { os: ubuntu-18.04   , target: i686-unknown-linux-gnu      , use-cross: use-cross }
+          - { os: ubuntu-18.04   , target: i686-unknown-linux-musl     , use-cross: use-cross }
+          - { os: ubuntu-18.04   , target: x86_64-unknown-linux-gnu    , use-cross: use-cross }
+          - { os: ubuntu-18.04   , target: x86_64-unknown-linux-musl   , use-cross: use-cross }
+          - { os: ubuntu-16.04   , target: x86_64-unknown-linux-gnu    , use-cross: use-cross }
+          - { os: macos-latest   , target: x86_64-apple-darwin         }
+          - { os: windows-latest , target: i686-pc-windows-gnu         }
+          - { os: windows-latest , target: i686-pc-windows-msvc        }
+          - { os: windows-latest , target: x86_64-pc-windows-gnu , toolchain: nightly-x86_64-pc-windows-gnu }  ## ! maint: [rivy; due 2020-21-03] disable/remove when rust beta >= v1.43.0 is available (~mid-March) ;; [rivy; 2020-01-21] may break due to rust bug; follow possible solution from GH:rust-lang/rust#47048 (refs: GH:rust-lang/rust#47048 , GH:rust-lang/rust#53454 , GH:bike-barn/hermit#172)
+          # - { os: windows-latest , target: x86_64-pc-windows-gnu , toolchain: beta-x86_64-pc-windows-gnu }  ## ! maint: [rivy; due 2020-21-03; due 2020-01-05] enable when rust beta >= v1.43.0 is available (~mid-March); disable when rust stable >= 1.43.0 is available (~early-May)
+          # - { os: windows-latest , target: x86_64-pc-windows-gnu       }  ## note: requires rust >= 1.43.0 to link correctly # ! maint: [rivy; due 2020-01-05] enable when rust stable >= 1.43.0 is available
+          - { os: windows-latest , target: x86_64-pc-windows-msvc      }
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install any prerequisites
+      shell: bash
+      run: |
+        case ${{ matrix.job.target }} in
+          arm-unknown-linux-gnueabihf) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
+        esac
+    - name: Initialize workflow variables
+      id: vars
+      shell: bash
+      run: |
+        # toolchain
+        TOOLCHAIN="stable" ## default to "stable" toolchain
+        # * specify alternate TOOLCHAIN for *-pc-windows-gnu targets; gnu targets on Windows are broken for the standard *-pc-windows-msvc toolchain (refs: <https://github.com/rust-lang/rust/issues/47048>, <https://github.com/rust-lang/rust/issues/53454>, <https://github.com/rust-lang/cargo/issues/6754>)
+        case ${{ matrix.job.target }} in *-pc-windows-gnu) TOOLCHAIN="stable-${{ matrix.job.target }}" ;; esac;
+        # * use requested TOOLCHAIN if specified
+        if [ -n "${{ matrix.job.toolchain }}" ]; then TOOLCHAIN="${{ matrix.job.toolchain }}" ; fi
+        echo set-output name=TOOLCHAIN::${TOOLCHAIN}
+        echo ::set-output name=TOOLCHAIN::${TOOLCHAIN}
+        # staging directory
+        STAGING='_staging'
+        echo set-output name=STAGING::${STAGING}
+        echo ::set-output name=STAGING::${STAGING}
+        # determine EXE suffix
+        EXE_suffix="" ; case ${{ matrix.job.target }} in *-pc-windows-*) EXE_suffix=".exe" ;; esac;
+        echo set-output name=EXE_suffix::${EXE_suffix}
+        echo ::set-output name=EXE_suffix::${EXE_suffix}
+        # parse commit reference info
+        REF_NAME=${GITHUB_REF#refs/*/}
+        unset REF_BRANCH ; case ${GITHUB_REF} in refs/heads/*) REF_BRANCH=${GITHUB_REF#refs/heads/} ;; esac;
+        unset REF_TAG ; case ${GITHUB_REF} in refs/tags/*) REF_TAG=${GITHUB_REF#refs/tags/} ;; esac;
+        REF_SHAS=${GITHUB_SHA:0:8}
+        echo set-output name=REF_NAME::${REF_NAME}
+        echo set-output name=REF_BRANCH::${REF_BRANCH}
+        echo set-output name=REF_TAG::${REF_TAG}
+        echo set-output name=REF_SHAS::${REF_SHAS}
+        echo ::set-output name=REF_NAME::${REF_NAME}
+        echo ::set-output name=REF_BRANCH::${REF_BRANCH}
+        echo ::set-output name=REF_TAG::${REF_TAG}
+        echo ::set-output name=REF_SHAS::${REF_SHAS}
+        # parse target
+        unset TARGET_ARCH ; case ${{ matrix.job.target }} in arm-unknown-linux-gnueabihf) TARGET_ARCH=arm ;; i686-*) TARGET_ARCH=i686 ;; x86_64-*) TARGET_ARCH=x86_64 ;; esac;
+        echo set-output name=TARGET_ARCH::${TARGET_ARCH}
+        echo ::set-output name=TARGET_ARCH::${TARGET_ARCH}
+        unset TARGET_OS ; case ${{ matrix.job.target }} in *-linux-*) TARGET_OS=linux ;; *-apple-*) TARGET_OS=macos ;; *-windows-*) TARGET_OS=windows ;; esac;
+        echo set-output name=TARGET_OS::${TARGET_OS}
+        echo ::set-output name=TARGET_OS::${TARGET_OS}
+        # package name
+        PKG_suffix=".tar.gz" ; case ${{ matrix.job.target }} in *-pc-windows-*) PKG_suffix=".zip" ;; esac;
+        PKG_BASENAME=${PROJECT_NAME}-${REF_TAG:-$REF_SHAS}-${{ matrix.job.target }}
+        PKG_NAME=${PKG_BASENAME}${PKG_suffix}
+        echo set-output name=PKG_suffix::${PKG_suffix}
+        echo set-output name=PKG_BASENAME::${PKG_BASENAME}
+        echo set-output name=PKG_NAME::${PKG_NAME}
+        echo ::set-output name=PKG_suffix::${PKG_suffix}
+        echo ::set-output name=PKG_BASENAME::${PKG_BASENAME}
+        echo ::set-output name=PKG_NAME::${PKG_NAME}
+        # deployable tag? (ie, leading "vM" or "M"; M == version number)
+        unset DEPLOY ; if [[ $REF_TAG =~ ^[vV]?[0-9].* ]]; then DEPLOY='true' ; fi
+        echo set-output name=DEPLOY::${DEPLOY:-<empty>/false}
+        echo ::set-output name=DEPLOY::${DEPLOY}
+        # target-specific options
+        # * CARGO_FEATURES_OPTION
+        CARGO_FEATURES_OPTION='' ;
+        if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
+        echo set-output name=CARGO_FEATURES_OPTION::${CARGO_FEATURES_OPTION}
+        echo ::set-output name=CARGO_FEATURES_OPTION::${CARGO_FEATURES_OPTION}
+        # * CARGO_USE_CROSS (truthy)
+        CARGO_USE_CROSS='true' ; case '${{ matrix.job.use-cross }}' in ''|0|f|false|n|no) unset CARGO_USE_CROSS ;; esac;
+        echo set-output name=CARGO_USE_CROSS::${CARGO_USE_CROSS:-<empty>/false}
+        echo ::set-output name=CARGO_USE_CROSS::${CARGO_USE_CROSS}
+        # # * `arm` cannot be tested on ubuntu-* hosts (b/c testing is currently primarily done via comparison of target outputs with built-in outputs and the `arm` target is not executable on the host)
+        JOB_DO_TESTING="true"
+        case ${{ matrix.job.target }} in arm-*) unset JOB_DO_TESTING ;; esac;
+        echo set-output name=JOB_DO_TESTING::${JOB_DO_TESTING:-<empty>/false}
+        echo ::set-output name=JOB_DO_TESTING::${JOB_DO_TESTING}
+        # # * test only binary for arm-type targets
+        unset CARGO_TEST_OPTIONS
+        unset CARGO_TEST_OPTIONS ; case ${{ matrix.job.target }} in arm-*) CARGO_TEST_OPTIONS="--bin ${PROJECT_NAME}" ;; esac;
+        echo set-output name=CARGO_TEST_OPTIONS::${CARGO_TEST_OPTIONS}
+        echo ::set-output name=CARGO_TEST_OPTIONS::${CARGO_TEST_OPTIONS}
+        # * strip executable?
+        STRIP="strip" ; case ${{ matrix.job.target }} in arm-unknown-linux-gnueabihf) STRIP="arm-linux-gnueabihf-strip" ;; *-pc-windows-msvc) STRIP="" ;; esac;
+        echo set-output name=STRIP::${STRIP}
+        echo ::set-output name=STRIP::${STRIP}
+    - name: Create all needed build/work directories
+      shell: bash
+      run: |
+        mkdir -p '${{ steps.vars.outputs.STAGING }}'
+        mkdir -p '${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_BASENAME }}'
+        # mkdir -p '${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_BASENAME }}/autocomplete'
+        mkdir -p '${{ steps.vars.outputs.STAGING }}/dpkg'
+    - name: rust toolchain ~ install
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ steps.vars.outputs.TOOLCHAIN }}
+        target: ${{ matrix.job.target }}
+        override: true
+        profile: minimal # minimal component installation (ie, no documentation)
+    - name: Info
+      shell: bash
+      run: |
+        gcc --version || true
+        rustup -V
+        rustup toolchain list
+        rustup default
+        cargo -V
+        rustc -V
+    - name: Build
+      uses: actions-rs/cargo@v1
+      with:
+        use-cross: ${{ steps.vars.outputs.CARGO_USE_CROSS }}
+        command: build
+        args: --release --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
+    - name: Test
+      uses: actions-rs/cargo@v1
+      with:
+        use-cross: ${{ steps.vars.outputs.CARGO_USE_CROSS }}
+        command: test
+        args: --target=${{ matrix.job.target }} ${{ steps.vars.outputs.CARGO_TEST_OPTIONS}} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
+    - name: Archive executable artifacts
+      uses: actions/upload-artifact@master
+      with:
+        name: ${{ env.PROJECT_NAME }}-${{ matrix.job.target }}
+        path: target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}${{ steps.vars.outputs.EXE_suffix }}
+    - name: Package
+      shell: bash
+      run: |
+        # binary
+        cp 'target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}${{ steps.vars.outputs.EXE_suffix }}' '${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_BASENAME }}/'
+        # `strip` binary (if needed)
+        if [ -n "${{ steps.vars.outputs.STRIP }}" ]; then "${{ steps.vars.outputs.STRIP }}" '${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_BASENAME }}/${{ env.PROJECT_NAME }}${{ steps.vars.outputs.EXE_suffix }}' ; fi
+        # README and LICENSE
+        # * spell-checker:ignore EADME ICENSE
+        (shopt -s nullglob; for f in [R]"EADME"{,.*}; do cp $f '${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_BASENAME }}/' ; done)
+        (shopt -s nullglob; for f in [L]"ICENSE"{-*,}{,.*}; do cp $f '${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_BASENAME }}/' ; done)
+        # base compressed package
+        pushd '${{ steps.vars.outputs.STAGING }}/' >/dev/null
+        case ${{ matrix.job.target }} in
+          *-pc-windows-*) 7z -y a '${{ steps.vars.outputs.PKG_NAME }}' '${{ steps.vars.outputs.PKG_BASENAME }}'/* | tail -2 ;;
+          *) tar czf '${{ steps.vars.outputs.PKG_NAME }}' '${{ steps.vars.outputs.PKG_BASENAME }}'/* ;;
+        esac;
+        popd >/dev/null
+    - name: Publish
+      uses: softprops/action-gh-release@v1
+      if: steps.vars.outputs.DEPLOY
+      with:
+        files: |
+          ${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_NAME }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  ## fix! [rivy; 2020-22-01] `cargo tarpaulin` is unable to test this repo at the moment; alternate recipe or another testing framework?
+  # coverage:
+  #   name: Code Coverage
+  #   runs-on: ${{ matrix.job.os }}
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       # job: [ { os: ubuntu-latest }, { os: macos-latest }, { os: windows-latest } ]
+  #       job: [ { os: ubuntu-latest } ] ## cargo-tarpaulin is currently only available on linux
+  #   steps:
+  #   - uses: actions/checkout@v1
+  #   # - name: Reattach HEAD ## may be needed for accurate code coverage info
+  #   #   run: git checkout ${{ github.head_ref }}
+  #   - name: Initialize workflow variables
+  #     id: vars
+  #     shell: bash
+  #     run: |
+  #       # staging directory
+  #       STAGING='_staging'
+  #       echo set-output name=STAGING::${STAGING}
+  #       echo ::set-output name=STAGING::${STAGING}
+  #       # check for CODECOV_TOKEN availability (work-around for inaccessible 'secrets' object for 'if'; see <https://github.community/t5/GitHub-Actions/jobs-lt-job-id-gt-if-does-not-work-with-env-secrets/m-p/38549>)
+  #       unset HAS_CODECOV_TOKEN
+  #       if [ -n $CODECOV_TOKEN ]; then HAS_CODECOV_TOKEN='true' ; fi
+  #       echo set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}
+  #       echo ::set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}
+  #     env:
+  #       CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
+  #   - name: Create all needed build/work directories
+  #     shell: bash
+  #     run: |
+  #       mkdir -p '${{ steps.vars.outputs.STAGING }}/work'
+  #   - name: Install required packages
+  #     run: |
+  #       sudo apt-get -y install libssl-dev
+  #       pushd '${{ steps.vars.outputs.STAGING }}/work' >/dev/null
+  #       wget --no-verbose https://github.com/xd009642/tarpaulin/releases/download/0.9.3/cargo-tarpaulin-0.9.3-travis.tar.gz
+  #       tar xf cargo-tarpaulin-0.9.3-travis.tar.gz
+  #       cp cargo-tarpaulin "$(dirname -- "$(which cargo)")"/
+  #       popd >/dev/null
+  #   - name: Generate coverage
+  #     run: |
+  #       cargo tarpaulin --out Xml
+  #   - name: Upload coverage results (CodeCov.io)
+  #     # CODECOV_TOKEN (aka, "Repository Upload Token" for REPO from CodeCov.io) ## set via REPO/Settings/Secrets
+  #     # if: secrets.CODECOV_TOKEN (not supported {yet?}; see <https://github.community/t5/GitHub-Actions/jobs-lt-job-id-gt-if-does-not-work-with-env-secrets/m-p/38549>)
+  #     if: steps.vars.outputs.HAS_CODECOV_TOKEN
+  #     run: |
+  #       # CodeCov.io
+  #       cargo tarpaulin --out Xml
+  #       bash <(curl -s https://codecov.io/bash)
+  #     env:
+  #       CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -161,6 +161,27 @@ jobs:
         unset DEPLOY ; if [[ $REF_TAG =~ ^[vV]?[0-9].* ]]; then DEPLOY='true' ; fi
         echo set-output name=DEPLOY::${DEPLOY:-<empty>/false}
         echo ::set-output name=DEPLOY::${DEPLOY}
+        # DPKG architecture?
+        unset DPKG_ARCH ; case ${{ matrix.job.target }} in i686-*-linux-*) DPKG_ARCH=i686 ;; x86_64-*-linux-*) DPKG_ARCH=amd64 ;; esac;
+        echo set-output name=DPKG_ARCH::${DPKG_ARCH}
+        echo ::set-output name=DPKG_ARCH::${DPKG_ARCH}
+        # DPKG version?
+        unset DPKG_VERSION ; if [[ $REF_TAG =~ ^[vV]?[0-9].* ]]; then DPKG_VERSION=${REF_TAG/#[vV]/} ; fi
+        echo set-output name=DPKG_VERSION::${DPKG_VERSION}
+        echo ::set-output name=DPKG_VERSION::${DPKG_VERSION}
+        # DPKG base name/conflicts?
+        DPKG_BASENAME=${PROJECT_NAME}
+        DPKG_CONFLICTS=${PROJECT_NAME}-musl
+        case ${{ matrix.job.target }} in *-musl) DPKG_BASENAME=${PROJECT_NAME}-musl ; DPKG_CONFLICTS=${PROJECT_NAME} ;; esac;
+        echo set-output name=DPKG_BASENAME::${DPKG_BASENAME}
+        echo set-output name=DPKG_CONFLICTS::${DPKG_CONFLICTS}
+        echo ::set-output name=DPKG_BASENAME::${DPKG_BASENAME}
+        echo ::set-output name=DPKG_CONFLICTS::${DPKG_CONFLICTS}
+        # DPKG name
+        unset DPKG_NAME;
+        if [[ -n $DPKG_ARCH && -n $DPKG_VERSION ]]; then DPKG_NAME="${DPKG_BASENAME}_${DPKG_VERSION}_${DPKG_ARCH}.deb" ; fi
+        echo set-output name=DPKG_NAME::${DPKG_NAME}
+        echo ::set-output name=DPKG_NAME::${DPKG_NAME}
         # target-specific options
         # * CARGO_FEATURES_OPTION
         CARGO_FEATURES_OPTION='' ;
@@ -243,12 +264,34 @@ jobs:
           *) tar czf '${{ steps.vars.outputs.PKG_NAME }}' '${{ steps.vars.outputs.PKG_BASENAME }}'/* ;;
         esac;
         popd >/dev/null
+        # dpkg
+        if [ -n "${{ steps.vars.outputs.DPKG_NAME }}" ]; then
+          DPKG_DIR="${{ steps.vars.outputs.STAGING }}/dpkg"
+          # binary
+          install -Dm755 'target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}${{ steps.vars.outputs.EXE_suffix }}' "${DPKG_DIR}/usr/bin/${{ env.PROJECT_NAME }}${{ steps.vars.outputs.EXE_suffix }}"
+          if [ -n "${{ steps.vars.outputs.STRIP }}" ]; then "${{ steps.vars.outputs.STRIP }}" "${DPKG_DIR}/usr/bin/${{ env.PROJECT_NAME }}${{ steps.vars.outputs.EXE_suffix }}" ; fi
+          # README and LICENSE
+          # * spell-checker:ignore EADME ICENSE
+          (shopt -s nullglob; for f in [R]"EADME"{,.*}; do install -Dm644 "$f" "${DPKG_DIR}/usr/share/doc/${{ env.PROJECT_NAME }}/$f" ; done)
+          (shopt -s nullglob; for f in [L]"ICENSE"{-*,}{,.*}; do install -Dm644 "$f" "${DPKG_DIR}/usr/share/doc/${{ env.PROJECT_NAME }}/$f" ; done)
+          # # (auto-)completions
+          # install -Dm644 'target/${{ matrix.job.target }}/release/build/${{ env.PROJECT_NAME }}-'*/'out/${{ env.PROJECT_NAME }}.bash' "${DPKG_DIR}/usr/share/bash-completion/completions/${{ env.PROJECT_NAME }}"
+          # install -Dm644 'target/${{ matrix.job.target }}/release/build/${{ env.PROJECT_NAME }}-'*/'out/${{ env.PROJECT_NAME }}.fish' "${DPKG_DIR}/usr/share/fish/completions/completions/${{ env.PROJECT_NAME }}.fish"
+          # install -Dm644 'target/${{ matrix.job.target }}/release/build/${{ env.PROJECT_NAME }}-'*/'out/_${{ env.PROJECT_NAME }}' "${DPKG_DIR}/usr/share/zsh/vendor-completions/_${{ env.PROJECT_NAME }}"
+          # control file
+          mkdir -p "${DPKG_DIR}/DEBIAN"
+          printf "Package: ${{ steps.vars.outputs.DPKG_BASENAME }}\nVersion: ${{ steps.vars.outputs.DPKG_VERSION }}\nSection: utils\nPriority: optional\nMaintainer: ${{ env.PROJECT_AUTH }}\nArchitecture: ${{ steps.vars.outputs.DPKG_ARCH }}\nProvides: ${{ env.PROJECT_NAME }}\nConflicts: ${{ steps.vars.outputs.DPKG_CONFLICTS }}\nDescription: ${{ env.PROJECT_DESC }}\n" > "${DPKG_DIR}/DEBIAN/control"
+          ## cat "${DPKG_DIR}/DEBIAN/control"
+          # build dpkg
+          fakeroot dpkg-deb --build "${DPKG_DIR}" "${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.DPKG_NAME }}"
+        fi
     - name: Publish
       uses: softprops/action-gh-release@v1
       if: steps.vars.outputs.DEPLOY
       with:
         files: |
           ${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_NAME }}
+          ${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.DPKG_NAME }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -10,7 +10,7 @@ env:
   PROJECT_NAME: pastel
   PROJECT_DESC: "A command-line tool to generate, analyze, convert and manipulate colors"
   PROJECT_AUTH: "sharkdp"
-  RUST_MIN_SRV: "1.35.0"
+  RUST_MIN_SRV: "1.40.0"
 
 on: [push, pull_request]
 

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -1,11 +1,5 @@
 name: CICD
 
-# spell-checker:ignore (acronyms) CICD MSVC musl
-# spell-checker:ignore (names) CodeCOV MacOS MinGW Peltoche rivy sharkdp
-# spell-checker:ignore (jargon) SHAs softprops toolchain
-# spell-checker:ignore (shell/tools) choco clippy dmake dpkg esac fakeroot gmake grcov halium libssl mkdir nullglob popd printf pushd rustc rustfmt rustup shopt
-# spell-checker:ignore (misc) Ccodegen Cinline Coverflow RUSTFLAGS aarch gnueabihf issuecomment maint onexitbegin onexitend uutils
-
 env:
   PROJECT_NAME: pastel
   PROJECT_DESC: "A command-line tool to generate, analyze, convert and manipulate colors"
@@ -214,7 +208,6 @@ jobs:
       run: |
         mkdir -p '${{ steps.vars.outputs.STAGING }}'
         mkdir -p '${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_BASENAME }}'
-        # mkdir -p '${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_BASENAME }}/autocomplete'
         mkdir -p '${{ steps.vars.outputs.STAGING }}/dpkg'
     - name: rust toolchain ~ install
       uses: actions-rs/toolchain@v1
@@ -274,17 +267,11 @@ jobs:
           install -Dm755 'target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}${{ steps.vars.outputs.EXE_suffix }}' "${DPKG_DIR}/usr/bin/${{ env.PROJECT_NAME }}${{ steps.vars.outputs.EXE_suffix }}"
           if [ -n "${{ steps.vars.outputs.STRIP }}" ]; then "${{ steps.vars.outputs.STRIP }}" "${DPKG_DIR}/usr/bin/${{ env.PROJECT_NAME }}${{ steps.vars.outputs.EXE_suffix }}" ; fi
           # README and LICENSE
-          # * spell-checker:ignore EADME ICENSE
           (shopt -s nullglob; for f in [R]"EADME"{,.*}; do install -Dm644 "$f" "${DPKG_DIR}/usr/share/doc/${{ env.PROJECT_NAME }}/$f" ; done)
           (shopt -s nullglob; for f in [L]"ICENSE"{-*,}{,.*}; do install -Dm644 "$f" "${DPKG_DIR}/usr/share/doc/${{ env.PROJECT_NAME }}/$f" ; done)
-          # # (auto-)completions
-          # install -Dm644 'target/${{ matrix.job.target }}/release/build/${{ env.PROJECT_NAME }}-'*/'out/${{ env.PROJECT_NAME }}.bash' "${DPKG_DIR}/usr/share/bash-completion/completions/${{ env.PROJECT_NAME }}"
-          # install -Dm644 'target/${{ matrix.job.target }}/release/build/${{ env.PROJECT_NAME }}-'*/'out/${{ env.PROJECT_NAME }}.fish' "${DPKG_DIR}/usr/share/fish/completions/completions/${{ env.PROJECT_NAME }}.fish"
-          # install -Dm644 'target/${{ matrix.job.target }}/release/build/${{ env.PROJECT_NAME }}-'*/'out/_${{ env.PROJECT_NAME }}' "${DPKG_DIR}/usr/share/zsh/vendor-completions/_${{ env.PROJECT_NAME }}"
           # control file
           mkdir -p "${DPKG_DIR}/DEBIAN"
           printf "Package: ${{ steps.vars.outputs.DPKG_BASENAME }}\nVersion: ${{ steps.vars.outputs.DPKG_VERSION }}\nSection: utils\nPriority: optional\nMaintainer: ${{ env.PROJECT_AUTH }}\nArchitecture: ${{ steps.vars.outputs.DPKG_ARCH }}\nProvides: ${{ env.PROJECT_NAME }}\nConflicts: ${{ steps.vars.outputs.DPKG_CONFLICTS }}\nDescription: ${{ env.PROJECT_DESC }}\n" > "${DPKG_DIR}/DEBIAN/control"
-          ## cat "${DPKG_DIR}/DEBIAN/control"
           # build dpkg
           fakeroot dpkg-deb --build "${DPKG_DIR}" "${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.DPKG_NAME }}"
         fi
@@ -311,8 +298,6 @@ jobs:
           - { os: windows-latest , toolchain: nightly-x86_64-pc-windows-gnu }
     steps:
     - uses: actions/checkout@v1
-    # - name: Reattach HEAD ## may be needed for accurate code coverage info
-    #   run: git checkout ${{ github.head_ref }}
     - name: Initialize workflow variables
       id: vars
       shell: bash
@@ -325,16 +310,6 @@ jobs:
         if [ -n "${{ matrix.job.toolchain }}" ]; then TOOLCHAIN="${{ matrix.job.toolchain }}" ; fi
         echo set-output name=TOOLCHAIN::${TOOLCHAIN}
         echo ::set-output name=TOOLCHAIN::${TOOLCHAIN}
-        # staging directory
-        STAGING='_staging'
-        echo set-output name=STAGING::${STAGING}
-        echo ::set-output name=STAGING::${STAGING}
-        ## # check for CODECOV_TOKEN availability (work-around for inaccessible 'secrets' object for 'if'; see <https://github.community/t5/GitHub-Actions/jobs-lt-job-id-gt-if-does-not-work-with-env-secrets/m-p/38549>)
-        ## # note: CODECOV_TOKEN / HAS_CODECOV_TOKEN is not needed for public repositories when using AppVeyor, Azure Pipelines, CircleCI, GitHub Actions, Travis (see <https://docs.codecov.io/docs/about-the-codecov-bash-uploader#section-upload-token>)
-        ## unset HAS_CODECOV_TOKEN
-        ## if [ -n $CODECOV_TOKEN ]; then HAS_CODECOV_TOKEN='true' ; fi
-        ## echo set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}
-        ## echo ::set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}
         # target-specific options
         # * CARGO_FEATURES_OPTION
         CARGO_FEATURES_OPTION='--all-features' ;  ## default to '--all-features' for code coverage
@@ -364,10 +339,8 @@ jobs:
       uses: actions-rs/grcov@v0.1
     - name: Upload coverage results (to Codecov.io)
       uses: codecov/codecov-action@v1
-      # if: steps.vars.outputs.HAS_CODECOV_TOKEN
       with:
-        # token: ${{ secrets.CODECOV_TOKEN }}
         file: ${{ steps.coverage.outputs.report }}
-        flags: UnitTests, ${{ steps.vars.outputs.CODECOV_FLAGS }}
+        flags: ${{ steps.vars.outputs.CODECOV_FLAGS }}
         name: codecov-umbrella
         fail_ci_if_error: true

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -4,7 +4,7 @@ name: CICD
 # spell-checker:ignore (names) CodeCOV MacOS MinGW Peltoche rivy sharkdp
 # spell-checker:ignore (jargon) SHAs softprops toolchain
 # spell-checker:ignore (shell/tools) choco clippy dmake dpkg esac fakeroot gmake halium libssl mkdir nullglob popd printf pushd rustc rustfmt rustup shopt
-# spell-checker:ignore (misc) gnueabihf issuecomment maint onexitbegin onexitend uutils
+# spell-checker:ignore (misc) aarch gnueabihf issuecomment maint onexitbegin onexitend uutils
 
 env:
   PROJECT_NAME: pastel
@@ -87,6 +87,8 @@ jobs:
         job:
           # { os, target, cargo-options, features, use-cross, toolchain }
           - { os: ubuntu-latest  , target: arm-unknown-linux-gnueabihf , use-cross: use-cross }
+          - { os: ubuntu-18.04   , target: aarch64-unknown-linux-gnu   , use-cross: use-cross }
+          - { os: ubuntu-18.04   , target: i586-unknown-linux-gnu      , use-cross: use-cross }
           - { os: ubuntu-18.04   , target: i686-unknown-linux-gnu      , use-cross: use-cross }
           - { os: ubuntu-18.04   , target: i686-unknown-linux-musl     , use-cross: use-cross }
           - { os: ubuntu-18.04   , target: x86_64-unknown-linux-gnu    , use-cross: use-cross }
@@ -106,6 +108,7 @@ jobs:
       run: |
         case ${{ matrix.job.target }} in
           arm-unknown-linux-gnueabihf) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
+          aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
         esac
     - name: Initialize workflow variables
       id: vars
@@ -197,13 +200,13 @@ jobs:
         case ${{ matrix.job.target }} in arm-*) unset JOB_DO_TESTING ;; esac;
         echo set-output name=JOB_DO_TESTING::${JOB_DO_TESTING:-<empty>/false}
         echo ::set-output name=JOB_DO_TESTING::${JOB_DO_TESTING}
-        # # * test only binary for arm-type targets
+        # # * test only library units tests and binary for arm-type targets
         unset CARGO_TEST_OPTIONS
-        unset CARGO_TEST_OPTIONS ; case ${{ matrix.job.target }} in arm-*) CARGO_TEST_OPTIONS="--bin ${PROJECT_NAME}" ;; esac;
+        unset CARGO_TEST_OPTIONS ; case ${{ matrix.job.target }} in arm-* | aarch64-*) CARGO_TEST_OPTIONS="--lib --bin ${PROJECT_NAME}" ;; esac;
         echo set-output name=CARGO_TEST_OPTIONS::${CARGO_TEST_OPTIONS}
         echo ::set-output name=CARGO_TEST_OPTIONS::${CARGO_TEST_OPTIONS}
-        # * strip executable?
-        STRIP="strip" ; case ${{ matrix.job.target }} in arm-unknown-linux-gnueabihf) STRIP="arm-linux-gnueabihf-strip" ;; *-pc-windows-msvc) STRIP="" ;; esac;
+        # * executable for `strip`?
+        STRIP="strip" ; case ${{ matrix.job.target }} in arm-unknown-linux-gnueabihf) STRIP="arm-linux-gnueabihf-strip" ;; aarch64-unknown-linux-gnu) STRIP="aarch64-linux-gnu-strip" ;; *-pc-windows-msvc) STRIP="" ;; esac;
         echo set-output name=STRIP::${STRIP}
         echo ::set-output name=STRIP::${STRIP}
     - name: Create all needed build/work directories

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -239,9 +239,9 @@ jobs:
       matrix:
         # job: [ { os: ubuntu-latest }, { os: macos-latest }, { os: windows-latest } ]
         job:
-          - { os: ubuntu-latest }
-          - { os: macos-latest }
-          - { os: windows-latest , toolchain: nightly-x86_64-pc-windows-gnu }
+          - { os: ubuntu-latest , toolchain: nightly-2020-04-29 }
+          - { os: macos-latest , toolchain: nightly-2020-04-29 }
+          - { os: windows-latest , toolchain: nightly-2020-04-29-x86_64-pc-windows-gnu }
     steps:
     - uses: actions/checkout@v1
     - name: Initialize workflow variables

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -3,8 +3,8 @@ name: CICD
 # spell-checker:ignore (acronyms) CICD MSVC musl
 # spell-checker:ignore (names) CodeCOV MacOS MinGW Peltoche rivy sharkdp
 # spell-checker:ignore (jargon) SHAs softprops toolchain
-# spell-checker:ignore (shell/tools) choco clippy dmake dpkg esac fakeroot gmake halium libssl mkdir nullglob popd printf pushd rustc rustfmt rustup shopt
-# spell-checker:ignore (misc) aarch gnueabihf issuecomment maint onexitbegin onexitend uutils
+# spell-checker:ignore (shell/tools) choco clippy dmake dpkg esac fakeroot gmake grcov halium libssl mkdir nullglob popd printf pushd rustc rustfmt rustup shopt
+# spell-checker:ignore (misc) Ccodegen Cinline Coverflow RUSTFLAGS aarch gnueabihf issuecomment maint onexitbegin onexitend uutils
 
 env:
   PROJECT_NAME: pastel
@@ -298,56 +298,76 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  ## fix! [rivy; 2020-22-01] `cargo tarpaulin` is unable to test this repo at the moment; alternate recipe or another testing framework?
-  # coverage:
-  #   name: Code Coverage
-  #   runs-on: ${{ matrix.job.os }}
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       # job: [ { os: ubuntu-latest }, { os: macos-latest }, { os: windows-latest } ]
-  #       job: [ { os: ubuntu-latest } ] ## cargo-tarpaulin is currently only available on linux
-  #   steps:
-  #   - uses: actions/checkout@v1
-  #   # - name: Reattach HEAD ## may be needed for accurate code coverage info
-  #   #   run: git checkout ${{ github.head_ref }}
-  #   - name: Initialize workflow variables
-  #     id: vars
-  #     shell: bash
-  #     run: |
-  #       # staging directory
-  #       STAGING='_staging'
-  #       echo set-output name=STAGING::${STAGING}
-  #       echo ::set-output name=STAGING::${STAGING}
-  #       # check for CODECOV_TOKEN availability (work-around for inaccessible 'secrets' object for 'if'; see <https://github.community/t5/GitHub-Actions/jobs-lt-job-id-gt-if-does-not-work-with-env-secrets/m-p/38549>)
-  #       unset HAS_CODECOV_TOKEN
-  #       if [ -n $CODECOV_TOKEN ]; then HAS_CODECOV_TOKEN='true' ; fi
-  #       echo set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}
-  #       echo ::set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}
-  #     env:
-  #       CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
-  #   - name: Create all needed build/work directories
-  #     shell: bash
-  #     run: |
-  #       mkdir -p '${{ steps.vars.outputs.STAGING }}/work'
-  #   - name: Install required packages
-  #     run: |
-  #       sudo apt-get -y install libssl-dev
-  #       pushd '${{ steps.vars.outputs.STAGING }}/work' >/dev/null
-  #       wget --no-verbose https://github.com/xd009642/tarpaulin/releases/download/0.9.3/cargo-tarpaulin-0.9.3-travis.tar.gz
-  #       tar xf cargo-tarpaulin-0.9.3-travis.tar.gz
-  #       cp cargo-tarpaulin "$(dirname -- "$(which cargo)")"/
-  #       popd >/dev/null
-  #   - name: Generate coverage
-  #     run: |
-  #       cargo tarpaulin --out Xml
-  #   - name: Upload coverage results (CodeCov.io)
-  #     # CODECOV_TOKEN (aka, "Repository Upload Token" for REPO from CodeCov.io) ## set via REPO/Settings/Secrets
-  #     # if: secrets.CODECOV_TOKEN (not supported {yet?}; see <https://github.community/t5/GitHub-Actions/jobs-lt-job-id-gt-if-does-not-work-with-env-secrets/m-p/38549>)
-  #     if: steps.vars.outputs.HAS_CODECOV_TOKEN
-  #     run: |
-  #       # CodeCov.io
-  #       cargo tarpaulin --out Xml
-  #       bash <(curl -s https://codecov.io/bash)
-  #     env:
-  #       CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
+  coverage:
+    name: Code Coverage
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        # job: [ { os: ubuntu-latest }, { os: macos-latest }, { os: windows-latest } ]
+        job:
+          - { os: ubuntu-latest }
+          - { os: macos-latest }
+          - { os: windows-latest , toolchain: nightly-x86_64-pc-windows-gnu }
+    steps:
+    - uses: actions/checkout@v1
+    # - name: Reattach HEAD ## may be needed for accurate code coverage info
+    #   run: git checkout ${{ github.head_ref }}
+    - name: Initialize workflow variables
+      id: vars
+      shell: bash
+      run: |
+        # toolchain
+        TOOLCHAIN="nightly" ## default to "nightly" toolchain
+        # * use requested TOOLCHAIN if specified
+        if [ -n "${{ matrix.job.toolchain }}" ]; then TOOLCHAIN="${{ matrix.job.toolchain }}" ; fi
+        # * use requested TOOLCHAIN if specified
+        if [ -n "${{ matrix.job.toolchain }}" ]; then TOOLCHAIN="${{ matrix.job.toolchain }}" ; fi
+        echo set-output name=TOOLCHAIN::${TOOLCHAIN}
+        echo ::set-output name=TOOLCHAIN::${TOOLCHAIN}
+        # staging directory
+        STAGING='_staging'
+        echo set-output name=STAGING::${STAGING}
+        echo ::set-output name=STAGING::${STAGING}
+        ## # check for CODECOV_TOKEN availability (work-around for inaccessible 'secrets' object for 'if'; see <https://github.community/t5/GitHub-Actions/jobs-lt-job-id-gt-if-does-not-work-with-env-secrets/m-p/38549>)
+        ## # note: CODECOV_TOKEN / HAS_CODECOV_TOKEN is not needed for public repositories when using AppVeyor, Azure Pipelines, CircleCI, GitHub Actions, Travis (see <https://docs.codecov.io/docs/about-the-codecov-bash-uploader#section-upload-token>)
+        ## unset HAS_CODECOV_TOKEN
+        ## if [ -n $CODECOV_TOKEN ]; then HAS_CODECOV_TOKEN='true' ; fi
+        ## echo set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}
+        ## echo ::set-output name=HAS_CODECOV_TOKEN::${HAS_CODECOV_TOKEN}
+        # target-specific options
+        # * CARGO_FEATURES_OPTION
+        CARGO_FEATURES_OPTION='--all-features' ;  ## default to '--all-features' for code coverage
+        if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
+        echo set-output name=CARGO_FEATURES_OPTION::${CARGO_FEATURES_OPTION}
+        echo ::set-output name=CARGO_FEATURES_OPTION::${CARGO_FEATURES_OPTION}
+        # * CODECOV_FLAGS
+        CODECOV_FLAGS=$( echo "${{ matrix.job.os }}" | sed 's/[^[:alnum:]]/_/g' )
+        echo set-output name=CODECOV_FLAGS::${CODECOV_FLAGS}
+        echo ::set-output name=CODECOV_FLAGS::${CODECOV_FLAGS}
+    - name: rust toolchain ~ install
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ steps.vars.outputs.TOOLCHAIN }}
+        override: true
+        profile: minimal # minimal component installation (ie, no documentation)
+    - name: Test
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: {{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --no-fail-fast
+      env:
+        CARGO_INCREMENTAL: '0'
+        RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'
+    - name: Generate coverage data
+      id: coverage
+      uses: actions-rs/grcov@v0.1
+    - name: Upload coverage results (to Codecov.io)
+      uses: codecov/codecov-action@v1
+      # if: steps.vars.outputs.HAS_CODECOV_TOKEN
+      with:
+        # token: ${{ secrets.CODECOV_TOKEN }}
+        file: ${{ steps.coverage.outputs.report }}
+        flags: UnitTests, ${{ steps.vars.outputs.CODECOV_FLAGS }}
+        name: codecov-umbrella
+        fail_ci_if_error: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
 
     # Minimum Rust supported channel.
     - os: linux
-      rust: 1.35.0
+      rust: 1.40.0
       env: TARGET=x86_64-unknown-linux-gnu
 
 

--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,7 @@ include!("src/cli/colorpicker_tools.rs");
 include!("src/cli/cli.rs");
 
 fn main() {
-    let var = std::env::var_os("SHELL_COMPLETIONS_DIR").or(std::env::var_os("OUT_DIR"));
+    let var = std::env::var_os("SHELL_COMPLETIONS_DIR").or_else(|| std::env::var_os("OUT_DIR"));
     let outdir = match var {
         None => return,
         Some(outdir) => outdir,

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -1,6 +1,5 @@
 use std::borrow::Borrow;
 
-use atty;
 pub use atty::Stream;
 use lazy_static::lazy_static;
 

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -247,7 +247,7 @@ pub fn get_colormode() -> Mode {
     use std::env;
 
     let env_colorterm = env::var("COLORTERM").ok();
-    match env_colorterm.as_ref().map(|s| s.as_str()) {
+    match env_colorterm.as_deref() {
         Some("truecolor") | Some("24bit") => Mode::TrueColor,
         _ => Mode::Ansi8Bit,
     }

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -5,8 +5,8 @@ use clap::{crate_description, crate_name, crate_version, App, AppSettings, Arg, 
 #[cfg(pastel_normal_build)]
 use crate::colorpicker_tools::COLOR_PICKER_TOOLS;
 
-const SORT_OPTIONS: &[&'static str] = &["brightness", "luminance", "hue", "chroma", "random"];
-const DEFAULT_SORT_ORDER: &'static str = "hue";
+const SORT_OPTIONS: &[&str] = &["brightness", "luminance", "hue", "chroma", "random"];
+const DEFAULT_SORT_ORDER: &str = "hue";
 
 pub fn build_cli() -> App<'static, 'static> {
     let color_arg = Arg::with_name("color")

--- a/src/cli/colorpicker.rs
+++ b/src/cli/colorpicker.rs
@@ -87,5 +87,5 @@ pub fn run_external_colorpicker(picker: Option<&str>) -> Result<String> {
         }
     }
 
-    return Err(PastelError::NoColorPickerFound);
+    Err(PastelError::NoColorPickerFound)
 }

--- a/src/cli/commands/distinct.rs
+++ b/src/cli/commands/distinct.rs
@@ -49,7 +49,7 @@ fn print_colors(
 
         ci += 1;
     }
-    writeln!(out, "")?;
+    writeln!(out)?;
     Ok(())
 }
 
@@ -125,7 +125,7 @@ fn print_distance_matrix(
                 write!(out, "{} ", brush.paint(format!("{:6.2}", dist), style))?;
             }
         }
-        writeln!(out, "")?;
+        writeln!(out)?;
     }
     writeln!(out, "\n")?;
 

--- a/src/cli/commands/distinct.rs
+++ b/src/cli/commands/distinct.rs
@@ -28,8 +28,7 @@ fn print_colors(
     colors: &[Color],
     closest_pair: Option<(usize, usize)>,
 ) -> Result<()> {
-    let mut ci = 0;
-    for c in colors.iter() {
+    for (ci, c) in colors.iter().enumerate() {
         let tc = c.text_color();
         let mut style = tc.ansi_style();
         style.on(c);
@@ -46,8 +45,6 @@ fn print_colors(
             "{} ",
             brush.paint(format!("{}", c.to_rgb_hex_string(false)), style)
         )?;
-
-        ci += 1;
     }
     writeln!(out)?;
     Ok(())

--- a/src/cli/commands/distinct.rs
+++ b/src/cli/commands/distinct.rs
@@ -43,7 +43,7 @@ fn print_colors(
         write!(
             out,
             "{} ",
-            brush.paint(format!("{}", c.to_rgb_hex_string(false)), style)
+            brush.paint(c.to_rgb_hex_string(false).to_string(), style)
         )?;
     }
     writeln!(out)?;
@@ -95,7 +95,7 @@ fn print_distance_matrix(
         let tc = c.text_color();
         let mut style = tc.ansi_style();
         style.on(c);
-        format!("{}", brush.paint(c.to_rgb_hex_string(false), style))
+        brush.paint(c.to_rgb_hex_string(false), style)
     };
 
     write!(out, "\n\n{:6}  ", "")?;

--- a/src/cli/commands/distinct.rs
+++ b/src/cli/commands/distinct.rs
@@ -8,7 +8,7 @@ use pastel::{Fraction, HSLA};
 
 pub struct DistinctCommand;
 
-fn print_iteration(out: &mut dyn Write, brush: &Brush, stats: &IterationStatistics) -> Result<()> {
+fn print_iteration(out: &mut dyn Write, brush: Brush, stats: &IterationStatistics) -> Result<()> {
     let result = stats.distance_result;
     write!(
         out,
@@ -24,7 +24,7 @@ fn print_iteration(out: &mut dyn Write, brush: &Brush, stats: &IterationStatisti
 
 fn print_colors(
     out: &mut dyn Write,
-    brush: &Brush,
+    brush: Brush,
     colors: &[Color],
     closest_pair: Option<(usize, usize)>,
 ) -> Result<()> {
@@ -169,7 +169,7 @@ impl GenericCommand for DistinctCommand {
 
         let mut callback: Box<dyn FnMut(&IterationStatistics)> = if verbose_output {
             Box::new(|stats: &IterationStatistics| {
-                print_iteration(&mut stderr_lock, &brush_stderr, stats).ok();
+                print_iteration(&mut stderr_lock, brush_stderr, stats).ok();
             })
         } else {
             Box::new(|_: &IterationStatistics| {})

--- a/src/cli/commands/io.rs
+++ b/src/cli/commands/io.rs
@@ -60,7 +60,7 @@ impl<'a> ColorArgIterator<'a> {
 
         let line = line.trim();
 
-        parse_color(&line).ok_or(PastelError::ColorParseError(line.to_string()))
+        parse_color(&line).ok_or_else(|| PastelError::ColorParseError(line.to_string()))
     }
 
     pub fn from_color_arg(
@@ -79,7 +79,7 @@ impl<'a> ColorArgIterator<'a> {
                 ColorArgIterator::from_color_arg(config, &color_str, print_spectrum)
             }
             color_str => {
-                parse_color(color_str).ok_or(PastelError::ColorParseError(color_str.into()))
+                parse_color(color_str).ok_or_else(|| PastelError::ColorParseError(color_str.into()))
             }
         }
     }

--- a/src/cli/commands/paint.rs
+++ b/src/cli/commands/paint.rs
@@ -24,7 +24,7 @@ impl GenericCommand for PaintCommand {
         };
 
         let bg = if let Some(bg) = matches.value_of("on") {
-            Some(parse_color(bg).ok_or(PastelError::ColorParseError(bg.into()))?)
+            Some(parse_color(bg).ok_or_else(|| PastelError::ColorParseError(bg.into()))?)
         } else {
             None
         };

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -51,7 +51,7 @@ fn run() -> Result<ExitCode> {
             "auto" => {
                 if interactive_mode {
                     let env_color_mode = std::env::var("PASTEL_COLOR_MODE").ok();
-                    match env_color_mode.as_ref().map(|s| s.as_str()) {
+                    match env_color_mode.as_deref() {
                         Some("8bit") => Some(ansi::Mode::Ansi8Bit),
                         Some("24bit") => Some(ansi::Mode::TrueColor),
                         Some("off") => None,

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -76,6 +76,7 @@ impl Output<'_> {
             );
         }
 
+        #[allow(clippy::identity_op)]
         canvas.draw_text(
             text_position_y + 0 + text_y_offset,
             text_position_x,

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -17,7 +17,7 @@ pub struct Output<'a> {
 impl Output<'_> {
     pub fn new(handle: &mut dyn Write) -> Output {
         Output {
-            handle: handle,
+            handle,
             colors_shown: 0,
         }
     }

--- a/src/distinct.rs
+++ b/src/distinct.rs
@@ -148,12 +148,10 @@ impl<R: Rng> SimulatedAnnealing<R> {
                     result.closest_pair.1
                 } else if result.closest_pair.1 < self.parameters.num_fixed_colors {
                     result.closest_pair.0
+                } else if self.rng.gen() {
+                    result.closest_pair.0
                 } else {
-                    if self.rng.gen() {
-                        result.closest_pair.0
-                    } else {
-                        result.closest_pair.1
-                    }
+                    result.closest_pair.1
                 }
             };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,14 +71,12 @@ impl Color {
         let hue = 60.0
             * (if chroma == 0 {
                 0.0
+            } else if r == max_chroma {
+                mod_positive((g_s - b_s) / chroma_s, 6.0)
+            } else if g == max_chroma {
+                (b_s - r_s) / chroma_s + 2.0
             } else {
-                if r == max_chroma {
-                    mod_positive((g_s - b_s) / chroma_s, 6.0)
-                } else if g == max_chroma {
-                    (b_s - r_s) / chroma_s + 2.0
-                } else {
-                    (r_s - g_s) / chroma_s + 4.0
-                }
+                (r_s - g_s) / chroma_s + 4.0
             });
 
         let lightness = (Scalar::from(max_chroma) + Scalar::from(min_chroma)) / (255.0 * 2.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@ impl Color {
     /// - https://en.wikipedia.org/wiki/CIE_1931_color_space
     /// - https://en.wikipedia.org/wiki/SRGB
     pub fn from_xyz(x: Scalar, y: Scalar, z: Scalar, alpha: Scalar) -> Color {
+        #![allow(clippy::many_single_char_names)]
         let f = |c| {
             if c <= 0.003_130_8 {
                 12.92 * c
@@ -138,6 +139,7 @@ impl Color {
     /// Create a `Color` from LMS coordinates. This is the matrix inverse of the matrix that
     /// appears in `to_lms`.
     pub fn from_lms(l: Scalar, m: Scalar, s: Scalar, alpha: Scalar) -> Color {
+        #![allow(clippy::many_single_char_names)]
         let x = 1.91020 * l - 1.112_120 * m + 0.201_908 * s;
         let y = 0.37095 * l + 0.629_054 * m + 0.000_000 * s;
         let z = 0.00000 * l + 0.000_000 * m + 1.000_000 * s;
@@ -149,6 +151,7 @@ impl Color {
     ///
     /// See: https://en.wikipedia.org/wiki/Lab_color_space
     pub fn from_lab(l: Scalar, a: Scalar, b: Scalar, alpha: Scalar) -> Color {
+        #![allow(clippy::many_single_char_names)]
         const DELTA: Scalar = 6.0 / 29.0;
 
         let finv = |t| {
@@ -173,6 +176,7 @@ impl Color {
     ///
     /// See: https://en.wikipedia.org/wiki/Lab_color_space
     pub fn from_lch(l: Scalar, c: Scalar, h: Scalar, alpha: Scalar) -> Color {
+        #![allow(clippy::many_single_char_names)]
         const DEG2RAD: Scalar = std::f64::consts::PI / 180.0;
 
         let a = c * Scalar::cos(h * DEG2RAD);
@@ -300,6 +304,7 @@ impl Color {
     /// - https://en.wikipedia.org/wiki/CIE_1931_color_space
     /// - https://en.wikipedia.org/wiki/SRGB
     pub fn to_xyz(&self) -> XYZ {
+        #![allow(clippy::many_single_char_names)]
         let finv = |c_| {
             if c_ <= 0.04045 {
                 c_ / 12.92

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,9 @@ pub struct Color {
 }
 
 // Illuminant D65 constants used for Lab color space conversions.
-const D65_XN: Scalar = 0.950470;
+const D65_XN: Scalar = 0.950_470;
 const D65_YN: Scalar = 1.0;
-const D65_ZN: Scalar = 1.088830;
+const D65_ZN: Scalar = 1.088_830;
 
 impl Color {
     pub fn from_hsla(hue: Scalar, saturation: Scalar, lightness: Scalar, alpha: Scalar) -> Color {
@@ -123,7 +123,7 @@ impl Color {
     /// - https://en.wikipedia.org/wiki/SRGB
     pub fn from_xyz(x: Scalar, y: Scalar, z: Scalar, alpha: Scalar) -> Color {
         let f = |c| {
-            if c <= 0.0031308 {
+            if c <= 0.003_130_8 {
                 12.92 * c
             } else {
                 1.055 * Scalar::powf(c, 1.0 / 2.4) - 0.055
@@ -140,9 +140,9 @@ impl Color {
     /// Create a `Color` from LMS coordinates. This is the matrix inverse of the matrix that
     /// appears in `to_lms`.
     pub fn from_lms(l: Scalar, m: Scalar, s: Scalar, alpha: Scalar) -> Color {
-        let x = 1.91020 * l - 1.112120 * m + 0.201908 * s;
-        let y = 0.37095 * l + 0.629054 * m + 0.000000 * s;
-        let z = 0.00000 * l + 0.000000 * m + 1.000000 * s;
+        let x = 1.91020 * l - 1.112_120 * m + 0.201_908 * s;
+        let y = 0.37095 * l + 0.629_054 * m + 0.000_000 * s;
+        let z = 0.00000 * l + 0.000_000 * m + 1.000_000 * s;
         Color::from_xyz(x, y, z, alpha)
     }
 
@@ -550,17 +550,17 @@ impl Color {
         let (l, m, s, alpha) = match cb_ty {
             ColorblindnessType::Protanopia => {
                 let LMS { m, s, alpha, .. } = self.to_lms();
-                let l = 1.05118294 * m - 0.05116099 * s;
+                let l = 1.051_182_94 * m - 0.051_160_99 * s;
                 (l, m, s, alpha)
             }
             ColorblindnessType::Deuteranopia => {
                 let LMS { l, s, alpha, .. } = self.to_lms();
-                let m = 0.9513092 * l + 0.04866992 * s;
+                let m = 0.951_309_2 * l + 0.048_669_92 * s;
                 (l, m, s, alpha)
             }
             ColorblindnessType::Tritanopia => {
                 let LMS { l, m, alpha, .. } = self.to_lms();
-                let s = -0.86744736 * l + 1.86727089 * m;
+                let s = -0.867_447_36 * l + 1.867_270_89 * m;
                 (l, m, s, alpha)
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -878,7 +878,7 @@ impl ColorScale {
                     .iter()
                     .position(|c| position.value() < c.position.value());
 
-                let index = next_index.unwrap_or(self.color_stops.len());
+                let index = next_index.unwrap_or_else(|| self.color_stops.len());
 
                 let color_stop = ColorStop { color, position };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -868,6 +868,7 @@ impl ColorScale {
 
     /// Add a `Color` at the given position.
     pub fn add_stop(&mut self, color: Color, position: Fraction) -> &mut Self {
+        #![allow(clippy::float_cmp)]
         let same_position = self
             .color_stops
             .iter_mut()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -47,7 +47,7 @@ fn parse_degrees(input: &str) -> IResult<&str, f64> {
 fn parse_rads(input: &str) -> IResult<&str, f64> {
     let (input, rads) = double(input)?;
     let (input, _) = tag("rad")(input)?;
-    Ok((input, rads * 180. / 3.14159))
+    Ok((input, rads * 180. / std::f64::consts::PI))
 }
 
 fn parse_grads(input: &str) -> IResult<&str, f64> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,6 +15,7 @@ impl Hue {
 
     /// Return a hue value in the interval [0, 360].
     pub fn value(self) -> Scalar {
+        #![allow(clippy::float_cmp)]
         if self.unclipped == 360.0 {
             self.unclipped
         } else {


### PR DESCRIPTION
This is a GitHub Actions workflow for CICD that I created for a couple of other repositories.

- adds GitHub-Actions CICD workflow (includes arm-linux, x86-linux, macos, and windows builds/testing)
- includes automatic deployment to Github Releases when commit is version tagged (see example at <https://github.com/rivy/rs.pastel/releases/tag/v0.7.0.1>; note: fully automatically generated)

I've also added in automated debian packaging / deployment (see example at <https://github.com/rivy/rs.pastel/releases/tag/v0.7.0.2>).

Additional targets are easily added as well.

Fixes: #119