### PR TITLE
Close #122 - Add CMYK representation

### DIFF
--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -216,7 +216,7 @@ pub fn build_cli() -> App<'static, 'static> {
                                            "luminance", "brightness",
                                            "ansi-8bit", "ansi-24bit",
                                            "ansi-8bit-escapecode", "ansi-24bit-escapecode",
-                                           "name"])
+                                           "cmyk", "name"])
                         .case_insensitive(true)
                         .default_value("hex")
                         .required(true),

--- a/src/cli/commands/format.rs
+++ b/src/cli/commands/format.rs
@@ -40,6 +40,7 @@ impl ColorCommand for FormatCommand {
             "ansi-24bit" => replace_escape(&color.to_ansi_sequence(Mode::TrueColor)),
             "ansi-8bit-escapecode" => color.to_ansi_sequence(Mode::Ansi8Bit),
             "ansi-24bit-escapecode" => color.to_ansi_sequence(Mode::TrueColor),
+            "cmyk" => color.to_cmyk_string(Format::Spaces),
             "name" => similar_colors(color)[0].name.to_owned(),
             &_ => {
                 unreachable!("Unknown format type");


### PR DESCRIPTION
Adds a CMYK representation. References https://github.com/sharkdp/pastel/issues/122

Tested also with https://www.rapidtables.com/convert/color/rgb-to-cmyk.html

Tests:
```
$ pastel format cmyk 'rgb(255, 255, 255)'
cmyk(0, 0, 0, 0)
$ pastel format cmyk 'rgb(0, 0, 0)'
cmyk(0, 0, 0, 100)
$ pastel format cmyk 'rgb(19, 19, 1)'
cmyk(0, 0, 95, 93)
$ pastel format cmyk blue
cmyk(100, 100, 0, 0)
$ pastel format cmyk 'rgb(55, 55, 55)'
cmyk(0, 0, 0, 78)
$ pastel format cmyk 'rgb(136, 117, 78)'
cmyk(0, 14, 43, 47)
$ pastel format cmyk 'rgb(143, 114, 75)'
cmyk(0, 20, 48, 44)
$ pastel format cmyk 'rgb(143, 111, 76)'
cmyk(0, 22, 47, 44)
```