### PR TITLE
Make code coverage purely informational (not allowed to break the build)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,13 @@
+comment: true
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    changes:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -284,4 +284,4 @@ jobs:
         file: ${{ steps.coverage.outputs.report }}
         flags: ${{ steps.vars.outputs.CODECOV_FLAGS }}
         name: codecov-umbrella
-        fail_ci_if_error: true
+        fail_ci_if_error: false


### PR DESCRIPTION
Code coverage can break the build occasionally, for, IMO, undesirable reasons.

- Occasionally, the code coverage upload will fail due to unknown factors. The first commit should convert those failures to just warnings.

- And, second, if CodeCov is allowed, it can signal a build failure if coverage drops for a commit/PR. The second commit here adds a *.codecov.yml* configuration file that converts CodeCov comments to purely informational; builds always "pass". If you want it to fail for drops, there are lots of options, but I never found a set that I liked ... hence, info but always pass setting.

Lastly, if you don't like the CodeCov "chattyness" is your PRs (eg, <https://github.com/sharkdp/pastel/pull/125#issuecomment-633257909>), the first line of *.codecov.yml* can be changed to `comment: false` disabling the commentary. Lots of other configuration options are available but are really beyond my understanding/uses.