### PR TITLE
Added traits: from and display to all color struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # unreleased
 
 ## Features
+- Added `From` and `Display` traits for each color struct, see #133 (@bresilla)
+
 ## Bugfixes
 ## Changes
 ## Other

--- a/src/delta_e.rs
+++ b/src/delta_e.rs
@@ -86,39 +86,6 @@ pub fn ciede2000(color1: &Lab, color2: &Lab) -> f64 {
     (lightness.powi(2) + chroma.powi(2) + hue.powi(2) + r_sub_t * chroma * hue).sqrt()
 }
 
-
-pub fn cie94(color0: &Lab, color: &Lab) -> f64 {
-    let xc1 = (color0.a.powi(2) + color0.b.powi(2)).sqrt();
-    let xc2 = (color.a.powi(2) + color.b.powi(2)).sqrt();
-    let xdl = color.l - color0.l;
-    let mut xdc = xc2 - xc1;
-    let xde = ( (color0.l - color.l).powi(2) + (color0.a - color.a).powi(2) + (color0.b - color.b).powi(2) ).sqrt();
-
-    let mut xdh = xde.powi(2) - xdl.powi(2) - xdc.powi(2);
-    if xdh > 0.0 {
-        xdh = xdh.sqrt();
-    } else {
-        xdh = 0.0;
-    }
-
-    let xsc = 1.0 + 0.045 * xc1;
-    let xsh = 1.0 + 0.015 * xc1;
-    xdc /= xsc;
-    xdh /= xsh;
-
-    return ( xdl.powi(2) + xdc.powi(2) + xdh.powi(2) ).sqrt();
-}
-
-// Finds the index and distance from nearest color from a group of colors
-pub fn nearest(color: &Lab, colors: &Vec<Lab>, delta_f: &dyn Fn(&Lab, &Lab) -> f64) -> (usize, f64) {
-    return colors
-        .iter()
-        .map(|c| delta_f(color, c))
-        .enumerate()
-        .min_by(|(_, a), (_, b)| a.partial_cmp(&b).expect("NaN encountered"))
-        .unwrap();
-}
-
 fn get_h_prime_fn(x: f64, y: f64) -> f64 {
     let mut hue_angle;
 

--- a/src/delta_e.rs
+++ b/src/delta_e.rs
@@ -86,6 +86,39 @@ pub fn ciede2000(color1: &Lab, color2: &Lab) -> f64 {
     (lightness.powi(2) + chroma.powi(2) + hue.powi(2) + r_sub_t * chroma * hue).sqrt()
 }
 
+
+pub fn cie94(color0: &Lab, color: &Lab) -> f64 {
+    let xc1 = (color0.a.powi(2) + color0.b.powi(2)).sqrt();
+    let xc2 = (color.a.powi(2) + color.b.powi(2)).sqrt();
+    let xdl = color.l - color0.l;
+    let mut xdc = xc2 - xc1;
+    let xde = ( (color0.l - color.l).powi(2) + (color0.a - color.a).powi(2) + (color0.b - color.b).powi(2) ).sqrt();
+
+    let mut xdh = xde.powi(2) - xdl.powi(2) - xdc.powi(2);
+    if xdh > 0.0 {
+        xdh = xdh.sqrt();
+    } else {
+        xdh = 0.0;
+    }
+
+    let xsc = 1.0 + 0.045 * xc1;
+    let xsh = 1.0 + 0.015 * xc1;
+    xdc /= xsc;
+    xdh /= xsh;
+
+    return ( xdl.powi(2) + xdc.powi(2) + xdh.powi(2) ).sqrt();
+}
+
+// Finds the index and distance from nearest color from a group of colors
+pub fn nearest(color: &Lab, colors: &Vec<Lab>, delta_f: &dyn Fn(&Lab, &Lab) -> f64) -> (usize, f64) {
+    return colors
+        .iter()
+        .map(|c| delta_f(color, c))
+        .enumerate()
+        .min_by(|(_, a), (_, b)| a.partial_cmp(&b).expect("NaN encountered"))
+        .unwrap();
+}
+
 fn get_h_prime_fn(x: f64, y: f64) -> f64 {
     let mut hue_angle;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ impl Color {
     pub fn from_rgba(r: u8, g: u8, b: u8, alpha: Scalar) -> Color {
         // RGB to HSL conversion algorithm adapted from
         // https://en.wikipedia.org/wiki/HSL_and_HSV
-        Color::from(&RGBA::<u8>{ r, g, b, alpha })
+        Self::from(&RGBA::<u8>{ r, g, b, alpha })
 
     }
 
@@ -107,6 +107,12 @@ impl Color {
     /// See: https://en.wikipedia.org/wiki/Lab_color_space
     pub fn from_lch(l: Scalar, c: Scalar, h: Scalar, alpha: Scalar) -> Color {
         Self::from(&LCh{ l, c, h, alpha })
+    }
+
+    /// Create a `Color` from  the four colours of the CMYK model: Cyan, Magenta, Yellow and Black. 
+    /// The CMYK colours are subtractive. This means the colours get darker as you blend them together
+    pub fn from_cmyk(c: Scalar, m: Scalar, y: Scalar, k: Scalar) -> Color {
+        Self::from(&CMYK{ c, m, y, k })
     }
 
     /// Convert a `Color` to its hue, saturation, lightness and alpha values. The hue is given
@@ -523,6 +529,13 @@ impl Color {
     }
 }
 
+// by default Colors will be printed into HSLA fromat
+impl fmt::Display for Color {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", HSLA::from(self).to_string() )
+    }
+}
+
 impl fmt::Debug for Color {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Color::from_{}", self.to_rgb_string(Format::NoSpaces))
@@ -662,13 +675,17 @@ impl From<&LCh> for Color {
 }
 
 
-//from CMYK to Color so you can do -> let new_color = Color::from(&some_cmyk);
-// impl From<&CMYK> for Color {
-//     fn from(color: &CMYK) -> Self {
-//         #![allow(clippy::many_single_char_names)]
-//         // let new = RGBA<a
-//     }
-// }
+// from CMYK to Color so you can do -> let new_color = Color::from(&some_cmyk);
+impl From<&CMYK> for Color {
+    fn from(color: &CMYK) -> Self {
+        #![allow(clippy::many_single_char_names)]
+        let r = 255.0 * ((1.0 - color.c ) / 100.0) * (( 1.0 - color.k ) / 100.0);
+        let g = 255.0 * ((1.0 - color.m ) / 100.0) * (( 1.0 - color.k ) / 100.0);
+        let b = 255.0 * ((1.0 - color.y ) / 100.0) * (( 1.0 - color.k ) / 100.0);
+
+        Color::from(&RGBA::<f64>{ r, g, b, alpha: 1.0 })
+    }
+}
 
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,7 +548,6 @@ impl PartialEq for Color {
     }
 }
 
-//from HSLA to Color so you can do -> let new_color = Color::from(&some_hsla);
 impl From<&HSLA> for Color {
     fn from(color: &HSLA) -> Self {
         Color {
@@ -560,7 +559,6 @@ impl From<&HSLA> for Color {
     }
 }
 
-//from RGBA to Color so you can do -> let new_color = Color::from(&some_rgba);
 impl From<&RGBA<u8>> for Color {
     fn from(color: &RGBA<u8>) -> Self {
         let max_chroma = u8::max(u8::max(color.r, color.g), color.b);
@@ -594,7 +592,6 @@ impl From<&RGBA<u8>> for Color {
     }
 }
 
-//from RGBA to Color so you can do -> let new_color = Color::from(&some_rgba);
 impl From<&RGBA<f64>> for Color {
     fn from(color: &RGBA<f64>) -> Self {
         let r = Scalar::round(clamp(0.0, 255.0, 255.0 * color.r)) as u8;
@@ -605,7 +602,6 @@ impl From<&RGBA<f64>> for Color {
 }
 
 
-//from XYZ to Color so you can do -> let new_color = Color::from(&some_xyz);
 impl From<&XYZ> for Color {
     fn from(color: &XYZ) -> Self {
         #![allow(clippy::many_single_char_names)]
@@ -626,7 +622,6 @@ impl From<&XYZ> for Color {
 }
 
 
-//from LMS to Color so you can do -> let new_color = Color::from(&some_lms);
 impl From<&LMS> for Color {
     fn from(color: &LMS) -> Self {
         #![allow(clippy::many_single_char_names)]
@@ -637,7 +632,6 @@ impl From<&LMS> for Color {
     }
 }
 
-//from LAB to Color so you can do -> let new_color = Color::from(&some_lab);
 impl From<&Lab> for Color {
     fn from(color: &Lab) -> Self {
         #![allow(clippy::many_single_char_names)]
@@ -661,7 +655,6 @@ impl From<&Lab> for Color {
 }
 
 
-//from LCh to Color so you can do -> let new_color = Color::from(&some_lch);
 impl From<&LCh> for Color {
     fn from(color: &LCh) -> Self {
         #![allow(clippy::many_single_char_names)]
@@ -715,7 +708,6 @@ impl ColorSpace for RGBA<f64> {
     }
 }
 
-//from Color to RGBA<f64> so you can do -> let new_rgba = RGBA::<f64>::from(&some_color);
 impl From<&Color> for RGBA<f64> {
     fn from(color: &Color) -> Self {
         let h_s = color.hue.value() / 60.0;
@@ -748,7 +740,6 @@ impl From<&Color> for RGBA<f64> {
     }
 }
 
-//from Color to RGBA<u8> so you can do -> let new_rgba = RGBA::<u8>::from(&some_color);
 impl From<&Color> for RGBA<u8> {
     fn from(color: &Color) -> Self {
         let c = RGBA::<f64>::from(color);
@@ -818,7 +809,6 @@ impl ColorSpace for HSLA {
     }
 }
 
-//from Color to HSLA so you can do -> let new_hsla = HSLA::from(&some_color);
 impl From<&Color> for HSLA {
     fn from(color: &Color) -> Self {
         HSLA {
@@ -849,7 +839,6 @@ pub struct XYZ {
     pub alpha: Scalar,
 }
 
-//from Color to XYZ so you can do -> let new_xyz = XYZ::from(&some_color);
 impl From<&Color> for XYZ {
     fn from(color: &Color) -> Self {
         #![allow(clippy::many_single_char_names)]
@@ -901,7 +890,6 @@ pub struct LMS {
     pub alpha: Scalar,
 }
 
-//from Color to LMS so you can do -> let new_lsm = LMS::from(&some_color);
 impl From<&Color> for LMS {
     fn from(color: &Color) -> Self {
         let XYZ { x, y, z, alpha } = XYZ::from(color);
@@ -952,7 +940,6 @@ impl ColorSpace for Lab {
     }
 }
 
-//from Color to LAB so you can do -> let new_lab = Lab::from(&some_color);
 impl From<&Color> for Lab {
     fn from(color: &Color) -> Self {
         let rec = XYZ::from(color);
@@ -1023,7 +1010,6 @@ impl ColorSpace for LCh {
     }
 }
 
-//from Color to LCh so you can do -> let new_lch = LCh::from(&some_color);
 impl From<&Color> for LCh {
     fn from(color: &Color) -> Self {
         let Lab { l, a, b, alpha } = Lab::from(color);
@@ -1056,7 +1042,6 @@ pub struct CMYK {
     pub k: Scalar,
 }
 
-//from Color to CMYK so you can do -> let new_cmyk = CMYK::from(&some_color);
 impl From<&Color> for CMYK {
     fn from(color: &Color) -> Self {
         let rgba = RGBA::<u8>::from(color);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -759,7 +759,7 @@ impl From<&Color> for RGBA<u8> {
 impl fmt::Display for RGBA<f64> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f,
-            "rgb({r:.3}, {g:.3}, {b:.3})",
+            "rgb({r}, {g}, {b})",
             r = self.r,
             g = self.g,
             b = self.b,
@@ -823,7 +823,7 @@ impl From<&Color> for HSLA {
 impl fmt::Display for HSLA {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f,
-            "hsl({h:.0}, {s:.1}, {l:.1})",
+            "hsl({h}, {s}, {l})",
             h = self.h,
             s = self.s,
             l = self.l,
@@ -871,7 +871,7 @@ impl From<&Color> for XYZ {
 impl fmt::Display for XYZ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f,
-            "XYZ({x:.0}, {y:.0}, {z:.0})",
+            "XYZ({x}, {y}, {z})",
             x = self.x,
             y = self.y,
             z = self.z,
@@ -904,7 +904,7 @@ impl From<&Color> for LMS {
 impl fmt::Display for LMS {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f,
-            "LMS({l:.0}, {m:.0}, {s:.0})",
+            "LMS({l}, {m}, {s})",
             l = self.l,
             m = self.m,
             s = self.s,
@@ -971,7 +971,7 @@ impl From<&Color> for Lab {
 impl fmt::Display for Lab {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f,
-            "Lab({l:.0}, {a:.0}, {b:.0})",
+            "Lab({l}, {a}, {b})",
             l = self.l,
             a = self.a,
             b = self.b,
@@ -1026,7 +1026,7 @@ impl From<&Color> for LCh {
 impl fmt::Display for LCh {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f,
-            "LCh({l:.0}, {c:.0}, {h:.0})",
+            "LCh({l}, {c}, {h})",
             l = self.l,
             c = self.c,
             h = self.h,
@@ -1073,10 +1073,10 @@ impl fmt::Display for CMYK {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f,
             "cmyk({c}, {m}, {y}, {k})",
-            c = (self.c * 100.0).round(),
-            m = (self.m * 100.0).round(),
-            y = (self.y * 100.0).round(),
-            k = (self.k * 100.0).round(),
+            c = self.c,
+            m = self.m,
+            y = self.y,
+            k = self.k,
         )
     }
 }


### PR DESCRIPTION
For each colorstruct (Color, Lab, RGB...) traits 'From' and 'Diplay'
are coded. Those are very important when you want simply comvert
from one color to another with standard Rust things:
`let new_color = Lab::from(&Color)`
or
`let new_color: Lab = somme_color.into()`

In addidtion another delta_e was added: cir94, which is faster
than ciede2000 bu more accurate than cie76.

Lastly, a function `nearest` was added that is 5 lines, but,
with your premission in the future, i want to add functionality
to extract colors fom image, and this function is needed. It
simply finds the index and distance from nearest color from a group of
colors