### PR TITLE
Added HEX as struct with all its traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,8 +136,7 @@ impl Color {
 
     /// Create a `Color` from HEX string. Shoud be exactly 6 chars or 7 with leading '#'
     pub fn from_hex(hex_string: &str) -> Color {
-        let val = if hex_string.starts_with("#") { &hex_string[1..] } else { hex_string };
-        Self::from(&HEX{ val: val.to_string() })
+        parser::parse_hex(hex_string).unwrap().1
     }
 
     /// Convert a `Color` to its hue, saturation, lightness and alpha values. The hue is given
@@ -679,12 +678,7 @@ impl From<&LMS> for Color {
 
 impl From<&HEX> for Color {
     fn from(hex: &HEX) -> Self {
-        #![allow(clippy::many_single_char_names)]
-        let r = u8::from_str_radix(&hex.val[..2], 16).unwrap_or(0);
-        let g = u8::from_str_radix(&hex.val[2..4], 16).unwrap_or(0);
-        let b = u8::from_str_radix(&hex.val[5..], 16).unwrap_or(0);
-    
-        Color::from(&RGBA::<u8>{ r, g, b, alpha: 1.0 })
+        parser::parse_color(&hex.val).unwrap()
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -66,7 +66,7 @@ fn parse_angle(input: &str) -> IResult<&str, f64> {
     alt((parse_turns, parse_grads, parse_rads, parse_degrees))(input)
 }
 
-fn parse_hex(input: &str) -> IResult<&str, Color> {
+pub fn parse_hex(input: &str) -> IResult<&str, Color> {
     let (input, _) = opt_hash_char(input)?;
     let (input, hex_chars) = hex_digit1(input)?;
     match hex_chars.len() {


### PR DESCRIPTION
I added HEX as its own struct since all other colors are, thus making very easy to change from HEX to any other color format with traits like `From`

I think this is quite important cos most of the people use HEX, and i know that hex is kinda RGB, but having it as its own struct makes it very easy to switch between formats and makes the whole library more uniform