### PR TITLE
Add Check for PASTEL_COLOR_MODE if COLORTERM is empty or NOT in truecolormode

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -243,13 +243,25 @@ impl ToAnsiStyle for Color {
 }
 
 #[cfg(not(windows))]
+pub fn get_colormode_if_colorterm_absent() -> Mode {
+    use std::env;
+    let env_color_mode = env::var("PASTEL_COLOR_MODE").ok();
+    match env_color_mode.as_deref() {
+        Some("8bit") => Mode::Ansi8Bit,
+        Some("24bit") => Mode::TrueColor,
+        _ => Mode::Ansi8Bit,
+    }
+}
+
+
+#[cfg(not(windows))]
 pub fn get_colormode() -> Mode {
     use std::env;
 
     let env_colorterm = env::var("COLORTERM").ok();
     match env_colorterm.as_deref() {
         Some("truecolor") | Some("24bit") => Mode::TrueColor,
-        _ => Mode::Ansi8Bit,
+        _ => get_colormode_if_colorterm_absent(),
     }
 }
 


### PR DESCRIPTION
#121 @sharkdp 

![2021-06-21_20-52-01](https://user-images.githubusercontent.com/6021980/122860439-91710380-d2d2-11eb-979c-93528ade75a7.png)


Hopefully this should solve the issue. What do you think? It is a _bit_ hacky , but... should work for all cases where COLORMODE is absent. 

EDIT: attached the wrong screenshot.