### PR TITLE
Add wayaland/gnome color picker support

### DIFF
--- a/src/cli/colorpicker.rs
+++ b/src/cli/colorpicker.rs
@@ -81,9 +81,15 @@ pub fn run_external_colorpicker(picker: Option<&str>) -> Result<String> {
 
             let color =
                 String::from_utf8(result.stdout).map_err(|_| PastelError::ColorInvalidUTF8)?;
-            let color = color.trim();
+            let color = color.trim().to_string();
 
-            return Ok(color.to_string());
+            // Check if tool requires some post processing of the output
+            if let Some(post_process) = tool.post_process {
+                return post_process(color)
+                    .map_err(|error| PastelError::ColorParseError(error.to_string()));
+            } else {
+                return Ok(color);
+            }
         }
     }
 


### PR DESCRIPTION
Gnome has a native a colorpicker api accessible via dbus (works with
wayland), this pr leverage it to add a new colorpicker tool.