### PR TITLE
Add zenity and yad to colorpicker tools

### DIFF
--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -190,6 +190,8 @@ pub fn build_cli() -> App<'static, 'static> {
                   - colorpicker (https://github.com/Jack12816/colorpicker)\n  \
                   - chameleon (https://github.com/seebye/chameleon)\n  \
                   - KColorChooser (https://kde.org/applications/graphics/org.kde.kcolorchooser)\n  \
+                  - zenity (https://wiki.gnome.org/Projects/Zenity)\n  \
+                  - yad (https://github.com/v1cont/yad)\n  \
                   - macOS built-in color picker")
                 .arg(
                     Arg::with_name("count")

--- a/src/cli/colorpicker_tools.rs
+++ b/src/cli/colorpicker_tools.rs
@@ -88,6 +88,20 @@ lazy_static! {
             version_output_starts_with: b"kcolorchooser",
             post_process: None,
         },
+        ColorPickerTool {
+            command: "zenity",
+            args: &["--color-selection"],
+            version_args: &["--version"],
+            version_output_starts_with: b"",
+            post_process: None,
+        },
+        ColorPickerTool {
+            command: "yad",
+            args: &["--color"],
+            version_args: &["--version"],
+            version_output_starts_with: b"",
+            post_process: None,
+        },
     ];
 }
 


### PR DESCRIPTION
This PR adds [zenity](https://wiki.gnome.org/Projects/Zenity/) and [yad](https://github.com/v1cont/yad) as possible color picker tools:  
```
pastel --color-picker zenity pick
pastel --color-picker yad pick
```
![image](https://user-images.githubusercontent.com/1058151/132094416-d812144c-d7e4-45af-82b0-8e46a04b557d.png)
