### PR TITLE
feat: add support for transparency

### DIFF
--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -25,7 +25,7 @@ pub fn build_cli() -> App<'static, 'static> {
              \n  - 'rgb(119, 136, 153)'\
              \n  - '119,136,153'\
              \n  - 'hsl(210, 14.3%, 53.3%)'\n\
-             Alpha transparency is also supported:
+             Alpha transparency is also supported:\
              \n  - '#77889980'\
              \n  - 'rgba(119, 136, 153, 0.5)'\
              \n  - 'hsla(210, 14.3%, 53.3%, 50%)'",

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -24,7 +24,11 @@ pub fn build_cli() -> App<'static, 'static> {
              \n  - 789\
              \n  - 'rgb(119, 136, 153)'\
              \n  - '119,136,153'\
-             \n  - 'hsl(210, 14.3%, 53.3%)'",
+             \n  - 'hsl(210, 14.3%, 53.3%)'\n\
+             Alpha transparency is also supported:
+             \n  - '#77889980'\
+             \n  - 'rgba(119, 136, 153, 0.5)'\
+             \n  - 'hsla(210, 14.3%, 53.3%, 50%)'",
         )
         .required(false)
         .multiple(true);

--- a/src/cli/hdcanvas.rs
+++ b/src/cli/hdcanvas.rs
@@ -41,7 +41,11 @@ impl Canvas {
     ) {
         for i in 0..height {
             for j in 0..width {
-                *self.pixel_mut(row + i, col + j) = Some(color.clone());
+                let px = self.pixel_mut(row + i, col + j);
+                *px = Some(match px {
+                    Some(backdrop) => backdrop.composite(color),
+                    None => color.clone(),
+                });
             }
         }
     }

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -35,7 +35,7 @@ impl Output<'_> {
         let text_position_x: usize = checkerboard_size + 2 * config.padding;
         let text_position_y: usize = 0;
 
-        let mut canvas = Canvas::new(checkerboard_size, 51, config.brush);
+        let mut canvas = Canvas::new(checkerboard_size, 60, config.brush);
         canvas.draw_checkerboard(
             checkerboard_position_y,
             checkerboard_position_x,

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -58,8 +58,8 @@ pub fn interpolate_angle(a: Scalar, b: Scalar, fraction: Fraction) -> Scalar {
 //
 // Note that this will round using omitted decimal places:
 //
-//     MaxPrecision::<3>::wrap(0.5004) //=> 0.500
-//     MaxPrecision::<3>::wrap(0.5005) //=> 0.501
+//     MaxPrecision::wrap(3, 0.5004) //=> 0.500
+//     MaxPrecision::wrap(3, 0.5005) //=> 0.501
 //
 pub struct MaxPrecision {
     precision: u32,

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -61,19 +61,20 @@ pub fn interpolate_angle(a: Scalar, b: Scalar, fraction: Fraction) -> Scalar {
 //     MaxPrecision::<3>::wrap(0.5004) //=> 0.500
 //     MaxPrecision::<3>::wrap(0.5005) //=> 0.501
 //
-pub struct MaxPrecision<const N: u32> {
+pub struct MaxPrecision {
+    precision: u32,
     inner: f64,
 }
 
-impl<const N: u32> MaxPrecision<N> {
-    pub fn wrap(inner: f64) -> Self {
-        Self { inner }
+impl MaxPrecision {
+    pub fn wrap(precision: u32, inner: f64) -> Self {
+        Self { precision, inner }
     }
 }
 
-impl<const N: u32> Display for MaxPrecision<N> {
+impl Display for MaxPrecision {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let pow_10 = 10u32.pow(N) as f64;
+        let pow_10 = 10u32.pow(self.precision) as f64;
         let rounded = (self.inner * pow_10).round() / pow_10;
         write!(f, "{}", rounded)
     }
@@ -97,9 +98,9 @@ fn test_interpolate_angle() {
 
 #[test]
 fn test_max_precision() {
-    assert_eq!(format!("{}", MaxPrecision::<3>::wrap(0.5)), "0.5");
-    assert_eq!(format!("{}", MaxPrecision::<3>::wrap(0.51)), "0.51");
-    assert_eq!(format!("{}", MaxPrecision::<3>::wrap(0.512)), "0.512");
-    assert_eq!(format!("{}", MaxPrecision::<3>::wrap(0.5124)), "0.512");
-    assert_eq!(format!("{}", MaxPrecision::<3>::wrap(0.5125)), "0.513");
+    assert_eq!(format!("{}", MaxPrecision::wrap(3, 0.5)), "0.5");
+    assert_eq!(format!("{}", MaxPrecision::wrap(3, 0.51)), "0.51");
+    assert_eq!(format!("{}", MaxPrecision::wrap(3, 0.512)), "0.512");
+    assert_eq!(format!("{}", MaxPrecision::wrap(3, 0.5124)), "0.512");
+    assert_eq!(format!("{}", MaxPrecision::wrap(3, 0.5125)), "0.513");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ impl Color {
                 "a",
                 format!(
                     ",{space}{alpha}",
-                    alpha = MaxPrecision::<3>::wrap(self.alpha),
+                    alpha = MaxPrecision::wrap(3, self.alpha),
                     space = space
                 ),
             )
@@ -186,7 +186,7 @@ impl Color {
                 "a",
                 format!(
                     ",{space}{alpha}",
-                    alpha = MaxPrecision::<3>::wrap(rgba.alpha),
+                    alpha = MaxPrecision::wrap(3, rgba.alpha),
                     space = space
                 ),
             )
@@ -233,7 +233,7 @@ impl Color {
                 "a",
                 format!(
                     ",{space}{alpha}",
-                    alpha = MaxPrecision::<3>::wrap(rgba.alpha),
+                    alpha = MaxPrecision::wrap(3, rgba.alpha),
                     space = space
                 ),
             )
@@ -319,7 +319,7 @@ impl Color {
             } else {
                 format!(
                     ",{space}{alpha}",
-                    alpha = MaxPrecision::<3>::wrap(self.alpha),
+                    alpha = MaxPrecision::wrap(3, self.alpha),
                     space = space
                 )
             }
@@ -349,7 +349,7 @@ impl Color {
             } else {
                 format!(
                     ",{space}{alpha}",
-                    alpha = MaxPrecision::<3>::wrap(self.alpha),
+                    alpha = MaxPrecision::wrap(3, self.alpha),
                     space = space
                 )
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,7 +221,7 @@ impl Color {
         )
     }
 
-    /// Format the color as a floating point RGB-representation string (`rgb(1.0, 0.5,  0)`). If the alpha channel
+    /// Format the color as a floating point RGB-representation string (`rgb(1.0, 0.5, 0)`). If the alpha channel
     /// is `1.0`, the simplified `rgb()` format will be used instead.
     pub fn to_rgb_float_string(&self, format: Format) -> String {
         let rgba = RGBA::<f64>::from(self);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1775,4 +1775,19 @@ mod tests {
         let c3 = Color::from_rgb(143, 111, 76);
         assert_eq!("cmyk(0, 22, 47, 44)", c3.to_cmyk_string(Format::Spaces));
     }
+
+    #[test]
+    fn alpha_interchangeable_hex_to_decimal() {
+        // We use a max of 3 decimal places when displaying RGB floating point
+        // alpha values. This test insures that is sufficient to interchange
+        // back and forth between hex (values 0..256) and float (values 0..=1),
+        // e.g. hex `80` is float `0.502`, which parses to hex `80`, and so on.
+        for alpha_int in 0..256 {
+            let alpha_float: f64 = alpha_int as f64 / 255.0;
+            let alpha_string_3digits = format!("{}", MaxPrecision::wrap(3, alpha_float));
+            let parsed_float = alpha_string_3digits.parse::<f64>().unwrap();
+            let parsed_int = (parsed_float * 255.0).round() as i32;
+            assert_eq!(alpha_int, parsed_int);
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,10 +151,11 @@ impl Color {
             h = self.hue.value(),
             s = 100.0 * self.saturation,
             l = 100.0 * self.lightness,
+            space = space,
             a = if self.alpha == 1.0 {
                 "".to_string()
             } else {
-                format!(",{space}{:.3}", self.alpha)
+                format!(",{space}{:.3}", self.alpha, space = space)
             }
         )
     }
@@ -176,10 +177,11 @@ impl Color {
             r = rgba.r,
             g = rgba.g,
             b = rgba.b,
+            space = space,
             a = if rgba.alpha == 1.0 {
                 "".to_string()
             } else {
-                format!(",{space}{:.3}", rgba.alpha)
+                format!(",{space}{:.3}", rgba.alpha, space = space)
             }
         )
     }
@@ -214,10 +216,11 @@ impl Color {
             r = rgba.r,
             g = rgba.g,
             b = rgba.b,
+            space = space,
             a = if rgba.alpha == 1.0 {
                 "".to_string()
             } else {
-                format!(",{space}{:.3}", rgba.alpha)
+                format!(",{space}{:.3}", rgba.alpha, space = space)
             }
         )
     }
@@ -286,10 +289,11 @@ impl Color {
             l = lab.l,
             a = lab.a,
             b = lab.b,
+            space = space,
             alpha = if self.alpha == 1.0 {
                 "".to_string()
             } else {
-                format!("{space}/{space}{:.2}%", self.alpha * 100.)
+                format!("{space}/{space}{:.2}%", self.alpha * 100., space = space)
             }
         )
     }
@@ -311,10 +315,11 @@ impl Color {
             l = lch.l,
             c = lch.c,
             h = lch.h,
+            space = space,
             alpha = if self.alpha == 1.0 {
                 "".to_string()
             } else {
-                format!("{space}/{space}{:.2}%", self.alpha * 100.)
+                format!("{space}/{space}{:.2}%", self.alpha * 100., space = space)
             }
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,14 +141,21 @@ impl Color {
         HSLA::from(self)
     }
 
-    /// Format the color as a HSL-representation string (`hsl(123, 50.3%, 80.1%)`).
+    /// Format the color as a HSL-representation string (`hsla(123, 50.3%, 80.1%, 0.4)`). If the
+    /// alpha channel is `1.0`, the simplified `hsl()` format will be used instead.
     pub fn to_hsl_string(&self, format: Format) -> String {
+        let space = if format == Format::Spaces { " " } else { "" };
         format!(
-            "hsl({:.0},{space}{:.1}%,{space}{:.1}%)",
-            self.hue.value(),
-            100.0 * self.saturation,
-            100.0 * self.lightness,
-            space = if format == Format::Spaces { " " } else { "" }
+            "hsl{a_prefix}({h:.0},{space}{s:.1}%,{space}{l:.1}%{a})",
+            a_prefix = if self.alpha == 1.0 { "" } else { "a" },
+            h = self.hue.value(),
+            s = 100.0 * self.saturation,
+            l = 100.0 * self.lightness,
+            a = if self.alpha == 1.0 {
+                "".to_string()
+            } else {
+                format!(",{space}{:.3}", self.alpha)
+            }
         )
     }
 
@@ -158,15 +165,22 @@ impl Color {
         RGBA::<u8>::from(self)
     }
 
-    /// Format the color as a RGB-representation string (`rgb(255, 127,  0)`).
+    /// Format the color as a RGB-representation string (`rgba(255, 127, 0, 0.5)`). If the alpha channel
+    /// is `1.0`, the simplified `rgb()` format will be used instead.
     pub fn to_rgb_string(&self, format: Format) -> String {
         let rgba = RGBA::<u8>::from(self);
+        let space = if format == Format::Spaces { " " } else { "" };
         format!(
-            "rgb({r},{space}{g},{space}{b})",
+            "rgb{a_prefix}({r},{space}{g},{space}{b}{a})",
+            a_prefix = if rgba.alpha == 1.0 { "" } else { "a" },
             r = rgba.r,
             g = rgba.g,
             b = rgba.b,
-            space = if format == Format::Spaces { " " } else { "" }
+            a = if rgba.alpha == 1.0 {
+                "".to_string()
+            } else {
+                format!(",{space}{:.3}", rgba.alpha)
+            }
         )
     }
 
@@ -189,27 +203,40 @@ impl Color {
         )
     }
 
-    /// Format the color as a floating point RGB-representation string (`rgb(1.0, 0.5,  0)`).
+    /// Format the color as a floating point RGB-representation string (`rgb(1.0, 0.5,  0)`). If the alpha channel
+    /// is `1.0`, the simplified `rgb()` format will be used instead.
     pub fn to_rgb_float_string(&self, format: Format) -> String {
         let rgba = RGBA::<f64>::from(self);
+        let space = if format == Format::Spaces { " " } else { "" };
         format!(
-            "rgb({r:.3},{space}{g:.3},{space}{b:.3})",
+            "rgb{a_prefix}({r:.3},{space}{g:.3},{space}{b:.3}{a})",
+            a_prefix = if rgba.alpha == 1.0 { "" } else { "a" },
             r = rgba.r,
             g = rgba.g,
             b = rgba.b,
-            space = if format == Format::Spaces { " " } else { "" }
+            a = if rgba.alpha == 1.0 {
+                "".to_string()
+            } else {
+                format!(",{space}{:.3}", rgba.alpha)
+            }
         )
     }
 
-    /// Format the color as a RGB-representation string (`#fc0070`).
+    /// Format the color as a RGB-representation string (`#fc0070`). The output will contain 6 hex
+    /// digits if the alpha channel is `1.0`, or 8 hex digits otherwise.
     pub fn to_rgb_hex_string(&self, leading_hash: bool) -> String {
         let rgba = self.to_rgba();
         format!(
-            "{}{:02x}{:02x}{:02x}",
+            "{}{:02x}{:02x}{:02x}{}",
             if leading_hash { "#" } else { "" },
             rgba.r,
             rgba.g,
-            rgba.b
+            rgba.b,
+            if rgba.alpha == 1.0 {
+                "".to_string()
+            } else {
+                format!("{:02x}", (rgba.alpha * 255.) as u8)
+            }
         )
     }
 
@@ -249,15 +276,21 @@ impl Color {
         Lab::from(self)
     }
 
-    /// Format the color as a Lab-representation string (`Lab(41, 83, -93)`).
+    /// Format the color as a Lab-representation string (`Lab(41, 83, -93 / 50%)`). If the alpha channel
+    /// is `1.0`, it won't be included in the output.
     pub fn to_lab_string(&self, format: Format) -> String {
         let lab = Lab::from(self);
+        let space = if format == Format::Spaces { " " } else { "" };
         format!(
-            "Lab({l:.0},{space}{a:.0},{space}{b:.0})",
+            "Lab({l:.0},{space}{a:.0},{space}{b:.0}{alpha})",
             l = lab.l,
             a = lab.a,
             b = lab.b,
-            space = if format == Format::Spaces { " " } else { "" }
+            alpha = if self.alpha == 1.0 {
+                "".to_string()
+            } else {
+                format!("{space}/{space}{:.2}%", self.alpha * 100.)
+            }
         )
     }
 
@@ -268,15 +301,21 @@ impl Color {
         LCh::from(self)
     }
 
-    /// Format the color as a LCh-representation string (`LCh(0.3, 0.2, 0.1)`).
+    /// Format the color as a LCh-representation string (`LCh(0.3, 0.2, 0.1 / 50%)`). If the alpha channel
+    /// is `1.0`, it won't be included in the output.
     pub fn to_lch_string(&self, format: Format) -> String {
         let lch = LCh::from(self);
+        let space = if format == Format::Spaces { " " } else { "" };
         format!(
-            "LCh({l:.0},{space}{c:.0},{space}{h:.0})",
+            "LCh({l:.0},{space}{c:.0},{space}{h:.0}{alpha})",
             l = lch.l,
             c = lch.c,
             h = lch.h,
-            space = if format == Format::Spaces { " " } else { "" }
+            alpha = if self.alpha == 1.0 {
+                "".to_string()
+            } else {
+                format!("{space}/{space}{:.2}%", self.alpha * 100.)
+            }
         )
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,18 +145,19 @@ impl Color {
     /// alpha channel is `1.0`, the simplified `hsl()` format will be used instead.
     pub fn to_hsl_string(&self, format: Format) -> String {
         let space = if format == Format::Spaces { " " } else { "" };
+        let (a_prefix, a) = if self.alpha == 1.0 {
+            ("", "".to_string())
+        } else {
+            ("a", format!(",{space}{:.3}", self.alpha, space = space))
+        };
         format!(
             "hsl{a_prefix}({h:.0},{space}{s:.1}%,{space}{l:.1}%{a})",
-            a_prefix = if self.alpha == 1.0 { "" } else { "a" },
+            space = space,
+            a_prefix = a_prefix,
             h = self.hue.value(),
             s = 100.0 * self.saturation,
             l = 100.0 * self.lightness,
-            space = space,
-            a = if self.alpha == 1.0 {
-                "".to_string()
-            } else {
-                format!(",{space}{:.3}", self.alpha, space = space)
-            }
+            a = a,
         )
     }
 
@@ -171,18 +172,19 @@ impl Color {
     pub fn to_rgb_string(&self, format: Format) -> String {
         let rgba = RGBA::<u8>::from(self);
         let space = if format == Format::Spaces { " " } else { "" };
+        let (a_prefix, a) = if self.alpha == 1.0 {
+            ("", "".to_string())
+        } else {
+            ("a", format!(",{space}{:.3}", rgba.alpha, space = space))
+        };
         format!(
             "rgb{a_prefix}({r},{space}{g},{space}{b}{a})",
-            a_prefix = if rgba.alpha == 1.0 { "" } else { "a" },
+            space = space,
+            a_prefix = a_prefix,
             r = rgba.r,
             g = rgba.g,
             b = rgba.b,
-            space = space,
-            a = if rgba.alpha == 1.0 {
-                "".to_string()
-            } else {
-                format!(",{space}{:.3}", rgba.alpha, space = space)
-            }
+            a = a,
         )
     }
 
@@ -210,18 +212,19 @@ impl Color {
     pub fn to_rgb_float_string(&self, format: Format) -> String {
         let rgba = RGBA::<f64>::from(self);
         let space = if format == Format::Spaces { " " } else { "" };
+        let (a_prefix, a) = if self.alpha == 1.0 {
+            ("", "".to_string())
+        } else {
+            ("a", format!(",{space}{:.3}", rgba.alpha, space = space))
+        };
         format!(
             "rgb{a_prefix}({r:.3},{space}{g:.3},{space}{b:.3}{a})",
-            a_prefix = if rgba.alpha == 1.0 { "" } else { "a" },
+            space = space,
+            a_prefix = a_prefix,
             r = rgba.r,
             g = rgba.g,
             b = rgba.b,
-            space = space,
-            a = if rgba.alpha == 1.0 {
-                "".to_string()
-            } else {
-                format!(",{space}{:.3}", rgba.alpha, space = space)
-            }
+            a = a,
         )
     }
 
@@ -600,8 +603,9 @@ impl Color {
         // Composite A over B (see https://en.wikipedia.org/wiki/Alpha_compositing)
         //
         //   αo = αa + αb(1 - αa)
-        //   Co = Ca * αa + Cb * αb(1 - αa)
-        //        -------------------------
+        //
+        //        Ca * αa + Cb * αb(1 - αa)
+        //   Co = -------------------------
         //                   αo
         //
         //       αo:  output alpha

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use std::fmt;
 
 use colorspace::ColorSpace;
 pub use helper::Fraction;
-use helper::{clamp, interpolate, interpolate_angle, mod_positive};
+use helper::{clamp, interpolate, interpolate_angle, mod_positive, MaxPrecision};
 use types::{Hue, Scalar};
 
 /// The representation of a color.
@@ -148,7 +148,14 @@ impl Color {
         let (a_prefix, a) = if self.alpha == 1.0 {
             ("", "".to_string())
         } else {
-            ("a", format!(",{space}{:.3}", self.alpha, space = space))
+            (
+                "a",
+                format!(
+                    ",{space}{alpha}",
+                    alpha = MaxPrecision::<3>::wrap(self.alpha),
+                    space = space
+                ),
+            )
         };
         format!(
             "hsl{a_prefix}({h:.0},{space}{s:.1}%,{space}{l:.1}%{a})",
@@ -175,7 +182,14 @@ impl Color {
         let (a_prefix, a) = if self.alpha == 1.0 {
             ("", "".to_string())
         } else {
-            ("a", format!(",{space}{:.3}", rgba.alpha, space = space))
+            (
+                "a",
+                format!(
+                    ",{space}{alpha}",
+                    alpha = MaxPrecision::<3>::wrap(rgba.alpha),
+                    space = space
+                ),
+            )
         };
         format!(
             "rgb{a_prefix}({r},{space}{g},{space}{b}{a})",
@@ -215,7 +229,14 @@ impl Color {
         let (a_prefix, a) = if self.alpha == 1.0 {
             ("", "".to_string())
         } else {
-            ("a", format!(",{space}{:.3}", rgba.alpha, space = space))
+            (
+                "a",
+                format!(
+                    ",{space}{alpha}",
+                    alpha = MaxPrecision::<3>::wrap(rgba.alpha),
+                    space = space
+                ),
+            )
         };
         format!(
             "rgb{a_prefix}({r:.3},{space}{g:.3},{space}{b:.3}{a})",
@@ -282,7 +303,7 @@ impl Color {
         Lab::from(self)
     }
 
-    /// Format the color as a Lab-representation string (`Lab(41, 83, -93 / 50%)`). If the alpha channel
+    /// Format the color as a Lab-representation string (`Lab(41, 83, -93, 0.5)`). If the alpha channel
     /// is `1.0`, it won't be included in the output.
     pub fn to_lab_string(&self, format: Format) -> String {
         let lab = Lab::from(self);
@@ -296,7 +317,11 @@ impl Color {
             alpha = if self.alpha == 1.0 {
                 "".to_string()
             } else {
-                format!("{space}/{space}{:.2}%", self.alpha * 100., space = space)
+                format!(
+                    ",{space}{alpha}",
+                    alpha = MaxPrecision::<3>::wrap(self.alpha),
+                    space = space
+                )
             }
         )
     }
@@ -308,7 +333,7 @@ impl Color {
         LCh::from(self)
     }
 
-    /// Format the color as a LCh-representation string (`LCh(0.3, 0.2, 0.1 / 50%)`). If the alpha channel
+    /// Format the color as a LCh-representation string (`LCh(0.3, 0.2, 0.1, 0.5)`). If the alpha channel
     /// is `1.0`, it won't be included in the output.
     pub fn to_lch_string(&self, format: Format) -> String {
         let lch = LCh::from(self);
@@ -322,7 +347,11 @@ impl Color {
             alpha = if self.alpha == 1.0 {
                 "".to_string()
             } else {
-                format!("{space}/{space}{:.2}%", self.alpha * 100., space = space)
+                format!(
+                    ",{space}{alpha}",
+                    alpha = MaxPrecision::<3>::wrap(self.alpha),
+                    space = space
+                )
             }
         )
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -28,18 +28,8 @@ fn comma_separated(input: &str) -> IResult<&str, &str> {
     space0(input)
 }
 
-fn slash_separated(input: &str) -> IResult<&str, &str> {
-    let (input, _) = space0(input)?;
-    let (input, _) = char('/')(input)?;
-    space0(input)
-}
-
 fn parse_separator(input: &str) -> IResult<&str, &str> {
     alt((comma_separated, space1))(input)
-}
-
-fn parse_alpha_separator(input: &str) -> IResult<&str, &str> {
-    alt((slash_separated, comma_separated, space1))(input)
 }
 
 fn opt_hash_char(s: &str) -> IResult<&str, Option<char>> {
@@ -82,7 +72,7 @@ fn parse_angle(input: &str) -> IResult<&str, f64> {
 
 fn parse_alpha<'a>(input: &'a str) -> IResult<&'a str, f64> {
     let (input, alpha) = opt(|input: &'a str| {
-        let (input, _) = parse_alpha_separator(input)?;
+        let (input, _) = parse_separator(input)?;
         alt((parse_percentage, double))(input)
     })(input)?;
     Ok((input, alpha.unwrap_or(1.0)))
@@ -479,18 +469,6 @@ fn parse_alpha_syntax() {
     assert_eq!(Some(rgba(255, 0, 0, 1.0)), parse_color("#ff0000ff"));
 
     // rgb/rgba
-    assert_eq!(Some(rgba(10, 0, 0, 1.0)), parse_color("rgb(10,0,0/1)"));
-    assert_eq!(Some(rgba(10, 0, 0, 1.0)), parse_color("rgb(10,0,0/ 1)"));
-    assert_eq!(Some(rgba(10, 0, 0, 1.0)), parse_color("rgb(10,0,0 /1)"));
-    assert_eq!(Some(rgba(10, 0, 0, 1.0)), parse_color("rgb(10,0,0 / 1)"));
-    assert_eq!(Some(rgba(10, 0, 0, 1.0)), parse_color("rgb(10,0,0/1.0)"));
-    assert_eq!(Some(rgba(10, 0, 0, 1.0)), parse_color("rgb(10,0,0/ 1.0)"));
-    assert_eq!(Some(rgba(10, 0, 0, 1.0)), parse_color("rgb(10,0,0 /1.0)"));
-    assert_eq!(Some(rgba(10, 0, 0, 1.0)), parse_color("rgb(10,0,0 / 1.0)"));
-    assert_eq!(Some(rgba(10, 0, 0, 1.0)), parse_color("rgb(10,0,0/100%)"));
-    assert_eq!(Some(rgba(10, 0, 0, 1.0)), parse_color("rgb(10,0,0/ 100%)"));
-    assert_eq!(Some(rgba(10, 0, 0, 1.0)), parse_color("rgb(10,0,0 /100%)"));
-    assert_eq!(Some(rgba(10, 0, 0, 1.0)), parse_color("rgb(10,0,0 / 100%)"));
     assert_eq!(Some(rgba(10, 0, 0, 1.0)), parse_color("rgb(10,0,0,1)"));
     assert_eq!(Some(rgba(10, 0, 0, 1.0)), parse_color("rgb(10,0,0, 1)"));
     assert_eq!(Some(rgba(10, 0, 0, 1.0)), parse_color("rgba(10,0,0,1)"));
@@ -499,14 +477,6 @@ fn parse_alpha_syntax() {
     assert_eq!(Some(rgba(10, 0, 0, 1.0)), parse_color("rgba(10,0,0, 1.0)"));
 
     // hsl/hsla
-    assert_eq!(
-        Some(Color::from_hsla(10.0, 0.5, 0.5, 1.0)),
-        parse_color("hsl(10,50%,50%/1)")
-    );
-    assert_eq!(
-        Some(Color::from_hsla(10.0, 0.5, 0.5, 1.0)),
-        parse_color("hsl(10,50%,50%/1.0)")
-    );
     assert_eq!(
         Some(Color::from_hsla(10.0, 0.5, 0.5, 1.0)),
         parse_color("hsl(10,50%,50%,1)")
@@ -525,14 +495,6 @@ fn parse_alpha_syntax() {
     );
 
     // lab
-    assert_eq!(
-        Some(Color::from_lab(10.0, 30.0, 50.0, 1.0)),
-        parse_color("lab(10,30,50/1)")
-    );
-    assert_eq!(
-        Some(Color::from_lab(10.0, 30.0, 50.0, 1.0)),
-        parse_color("lab(10,30,50/1.0)")
-    );
     assert_eq!(
         Some(Color::from_lab(10.0, 30.0, 50.0, 1.0)),
         parse_color("lab(10,30,50,1)")


### PR DESCRIPTION
This PR adds support for parsing and displaying partially transparent colors. It adds a new function `Color::composite` which implements simple [alpha compositing](https://en.wikipedia.org/wiki/Alpha_compositing), and uses this to enhance `Canvas::draw_rect` to support painting partially transparent pixels over existing pixels. This is used to enable drawing color previews for transparent colors (see example below).

Additionally, this PR enhances the parser to support parsing all common alpha formats, including:

- `RGBA`
- `RRGGBBAA`
- `rgba()`
- `hsla()`

The `lab` parser also supports specifying alpha. The alpha value may be provided as a double or percentage, and may be slash, comma, or space delimited; all of the following are valid:

- `rgba(255 127 0 0.4)`
- `rgba(255, 127, 0, 0.4)`
- `rgba(255, 127, 0, 40%)`

For backwards compatibility, `rgb()` and `hsl()` also support alpha values. You can check the `parse_alpha_syntax` test to see all supported formats.

All `Color::to_*_string` methods now include the alpha value when it's not `1.0`, and omit it when it is.

Closes #131.

## Open Questions

This PR doesn't update the simplified format used when displaying colors with `pastel format` (the alpha channel value will be displayed, but the color itself will be fully opaque). It also doesn't add support for rendering colored text with partial transparency.

## Example

```
$ pastel color 6633997f
```

![image](https://user-images.githubusercontent.com/18172185/166162167-a91dfe39-a60d-4346-9da5-f8fbe03a5646.png)
