### PR TITLE
Use PASTEL_COLOR_MODE in ansi::Brush::from_environment

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -22,7 +22,7 @@ pub enum Mode {
 pub struct UnknownColorModeError(pub String);
 
 impl Mode {
-    pub fn from_str(mode_str: &str) -> Result<Option<Self>, UnknownColorModeError> {
+    pub fn from_mode_str(mode_str: &str) -> Result<Option<Self>, UnknownColorModeError> {
         match mode_str {
             "24bit" | "truecolor" => Ok(Some(Mode::TrueColor)),
             "8bit" => Ok(Some(Mode::Ansi8Bit)),
@@ -284,7 +284,7 @@ impl Brush {
         let mode = if atty::is(stream) {
             let env_color_mode = std::env::var("PASTEL_COLOR_MODE").ok();
             match env_color_mode.as_deref() {
-                Some(mode_str) => Mode::from_str(mode_str)?,
+                Some(mode_str) => Mode::from_mode_str(mode_str)?,
                 None => get_colormode(),
             }
         } else {

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -268,7 +268,13 @@ impl Brush {
 
     pub fn from_environment(stream: Stream) -> Self {
         let mode = if atty::is(stream) {
-            get_colormode()
+            let env_color_mode = std::env::var("PASTEL_COLOR_MODE").ok();
+            match env_color_mode.as_deref() {
+                Some("8bit") => Some(Mode::Ansi8Bit),
+                Some("24bit") => Some(Mode::TrueColor),
+                Some("off") => None,
+                Some(_) | None => get_colormode(),
+            }
         } else {
             None
         };

--- a/src/cli/colorpicker.rs
+++ b/src/cli/colorpicker.rs
@@ -16,7 +16,7 @@ pub fn print_colorspectrum(config: &Config) -> Result<()> {
     let mut canvas = Canvas::new(
         width + 2 * config.padding,
         width + 2 * config.padding,
-        Brush::from_environment(Stream::Stderr),
+        Brush::from_environment(Stream::Stderr)?,
     );
     canvas.draw_rect(
         config.padding,

--- a/src/cli/commands/distinct.rs
+++ b/src/cli/commands/distinct.rs
@@ -129,7 +129,7 @@ impl GenericCommand for DistinctCommand {
     fn run(&self, out: &mut Output, matches: &ArgMatches, config: &Config) -> Result<()> {
         let stderr = io::stderr();
         let mut stderr_lock = stderr.lock();
-        let brush_stderr = Brush::from_environment(Stream::Stderr);
+        let brush_stderr = Brush::from_environment(Stream::Stderr)?;
         let verbose_output = matches.is_present("verbose");
 
         let count = matches.value_of("number").expect("required argument");

--- a/src/cli/error.rs
+++ b/src/cli/error.rs
@@ -1,3 +1,5 @@
+use crate::ansi;
+
 #[derive(Debug)]
 pub enum PastelError {
     UnknownColorMode(String),
@@ -63,6 +65,12 @@ impl From<std::io::Error> for PastelError {
             std::io::ErrorKind::BrokenPipe => PastelError::StdoutClosed,
             _ => PastelError::IoError(err),
         }
+    }
+}
+
+impl From<ansi::UnknownColorModeError> for PastelError {
+    fn from(err: ansi::UnknownColorModeError) -> PastelError {
+        PastelError::UnknownColorMode(err.0)
     }
 }
 

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -78,7 +78,7 @@ fn run() -> Result<ExitCode> {
                 if interactive_mode {
                     let env_color_mode = std::env::var("PASTEL_COLOR_MODE").ok();
                     match env_color_mode.as_deref() {
-                        Some(mode_str) => Mode::from_str(mode_str)?,
+                        Some(mode_str) => Mode::from_mode_str(mode_str)?,
                         None => {
                             let mode = ansi::get_colormode();
                             if mode == Some(ansi::Mode::Ansi8Bit)


### PR DESCRIPTION
This intends to resolve #121 and continues the work from #140. @sharkdp
 
Fixes the issue where the pick command only relied on the COLORTERM variable instead of looking for PASTEL_COLOR_MODE first. 

Caveats:
- A similar block of code exists in [cli/main.rs](https://github.com/sharkdp/pastel/blob/3719824a56fb9eb92eb960068e513b95486756a7/src/cli/main.rs#L77-L95) but uses global_matches which are not available for this method, so I'm not sure if avoiding this duplication is possible.
- There is no error handling in case of incorrect PASTEL_COLOR_MODE values - I decided to ignore this variable in such cases. In other places it's done by returning `PastelError::UnknownColorMode` but I couldn't do it here because Brush::from_environment doesn't return Result.