### PR TITLE
Add sort-by-binary-operation subcommand

### DIFF
--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -486,8 +486,8 @@ pub fn build_cli() -> Command<'static> {
         .subcommand(
             Command::new("sort-by-binary-operation")
                 .about("Sort colors by the given binary operation")
-                .long_about("Sort a list of colors by applying the given binary operation with \
-                            the given operand color to each color.")
+                .long_about("Sort a list of colors by the result of applying the given binary operation with \
+                            the given operand color.")
                 .alias("sort-binary-operation")
                 .arg(
                     Arg::new("binary-operation")

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -7,6 +7,7 @@ use crate::colorpicker_tools::COLOR_PICKER_TOOL_NAMES;
 
 const SORT_OPTIONS: &[&str] = &["brightness", "luminance", "hue", "chroma", "random"];
 const DEFAULT_SORT_ORDER: &str = "hue";
+const BINARY_OPERATION_OPTIONS: &[&str] = &[ "contrast", "distance-cie76", "distance-ciede2000" ];
 
 pub fn build_cli() -> Command<'static> {
     let color_arg = Arg::new("color")
@@ -481,6 +482,38 @@ pub fn build_cli() -> Command<'static> {
             Command::new("colorcheck")
                 .about("Check if your terminal emulator supports 24-bit colors.")
                 .hide(true),
+        )
+        .subcommand(
+            Command::new("sort-by-binary-operation")
+                .about("Sort colors by the given binary operation")
+                .long_about("Sort a list of colors by applying the given binary operation with \
+                            the given operand color to each color.")
+                .alias("sort-binary-operation")
+                .arg(
+                    Arg::new("binary-operation")
+                        .help("binary-operation")
+                        .possible_values(BINARY_OPERATION_OPTIONS)
+                        .required(true),
+                )
+                .arg(
+                    Arg::new("operand")
+                        .value_name("color")
+                        .help("The operand color which will be passed to each binary operation")
+                        .required(true),
+                )
+                .arg(
+                    Arg::new("reverse")
+                        .long("reverse")
+                        .short('r')
+                        .help("Reverse the sort order"),
+                )
+                .arg(
+                    Arg::new("unique")
+                        .long("unique")
+                        .short('u')
+                        .help("Remove duplicate colors (equality is determined via RGB values)"),
+                )
+                .arg(color_arg.clone()),
         )
         .arg(
             Arg::new("color-mode")

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -491,7 +491,7 @@ pub fn build_cli() -> Command<'static> {
                 .alias("sort-binary-operation")
                 .arg(
                     Arg::new("binary-operation")
-                        .help("binary-operation")
+                        .help("Binary operation")
                         .possible_values(BINARY_OPERATION_OPTIONS)
                         .required(true),
                 )

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -7,7 +7,7 @@ use crate::colorpicker_tools::COLOR_PICKER_TOOL_NAMES;
 
 const SORT_OPTIONS: &[&str] = &["brightness", "luminance", "hue", "chroma", "random"];
 const DEFAULT_SORT_ORDER: &str = "hue";
-const BINARY_OPERATION_OPTIONS: &[&str] = &[ "contrast", "distance-cie76", "distance-ciede2000" ];
+const BINARY_OPERATION_OPTIONS: &[&str] = &["contrast", "distance-cie76", "distance-ciede2000"];
 
 pub fn build_cli() -> Command<'static> {
     let color_arg = Arg::new("color")

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -17,6 +17,7 @@ mod prelude;
 mod random;
 mod show;
 mod sort;
+mod sort_binary_operation;
 mod traits;
 
 use traits::{ColorCommand, GenericCommand};
@@ -31,6 +32,7 @@ use paint::PaintCommand;
 use pick::PickCommand;
 use random::RandomCommand;
 use sort::SortCommand;
+use sort_binary_operation::SortBinaryOperationCommand;
 
 use io::ColorArgIterator;
 
@@ -64,6 +66,7 @@ impl Command {
             "paint" => Command::Generic(Box::new(PaintCommand)),
             "format" => Command::WithColor(Box::new(FormatCommand)),
             "colorcheck" => Command::Generic(Box::new(ColorCheckCommand)),
+            "sort-by-binary-operation" => Command::Generic(Box::new(SortBinaryOperationCommand)),
             _ => unreachable!("Unknown subcommand"),
         }
     }

--- a/src/cli/commands/sort_binary_operation.rs
+++ b/src/cli/commands/sort_binary_operation.rs
@@ -13,7 +13,9 @@ pub fn key_function(binary_operation: &str, operand: &Color, color: &Color) -> i
 
 impl GenericCommand for SortBinaryOperationCommand {
     fn run(&self, out: &mut Output, matches: &ArgMatches, config: &Config) -> Result<()> {
-        let binary_operation = matches.value_of("binary-operation").expect("required argument");
+        let binary_operation = matches
+            .value_of("binary-operation")
+            .expect("required argument");
 
         let mut print_spectrum = PrintSpectrum::Yes;
 

--- a/src/cli/commands/sort_binary_operation.rs
+++ b/src/cli/commands/sort_binary_operation.rs
@@ -1,0 +1,48 @@
+use crate::commands::prelude::*;
+
+pub struct SortBinaryOperationCommand;
+
+pub fn key_function(binary_operation: &str, operand: &Color, color: &Color) -> i32 {
+    match binary_operation {
+        "contrast" => (operand.contrast_ratio(color) * 1000.0) as i32,
+        "distance-cie76" => (operand.distance_delta_e_cie76(color) * 1000.0) as i32,
+        "distance-ciede2000" => (operand.distance_delta_e_ciede2000(color) * 1000.0) as i32,
+        _ => unreachable!("Unknown binary operation"),
+    }
+}
+
+impl GenericCommand for SortBinaryOperationCommand {
+    fn run(&self, out: &mut Output, matches: &ArgMatches, config: &Config) -> Result<()> {
+        let binary_operation = matches.value_of("binary-operation").expect("required argument");
+
+        let mut print_spectrum = PrintSpectrum::Yes;
+
+        let operand = ColorArgIterator::from_color_arg(
+            config,
+            matches.value_of("operand").expect("required argument"),
+            &mut print_spectrum,
+        )?;
+
+        let mut colors: Vec<Color> = vec![];
+        for color in ColorArgIterator::from_args(config, matches.values_of("color"))? {
+            colors.push(color?);
+        }
+
+        if matches.is_present("unique") {
+            colors.sort_by_key(|c| c.to_u32());
+            colors.dedup_by_key(|c| c.to_u32());
+        }
+
+        colors.sort_by_key(|c| key_function(binary_operation, &operand, c));
+
+        if matches.is_present("reverse") {
+            colors.reverse();
+        }
+
+        for color in colors {
+            out.show_color(config, &color)?;
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR adds a new subcommand: sort-by-binary-operation. The command takes a required `binary operation` argument, a single required `operand color` argument, and an optional list of colors. It then sorts the list of colors by the result of applying the given `binary operation` with the given `operand color`.

For example:
```pastel sort-by-binary-operation distance #ff4500 red orange```
Would act as:
```
sort [ distance(#ff4500, red)
     , distance(#ff4500, orange)
     ]
```
And you would come to find that the color of Reddit upvotes are indeed closer perceived as red than orange.

This is the list of `binary operation` options:
* contrast
* distance-cie76
* distance-ciede2000

They are the orderable binary operations of `Color`.

Some use cases are:
* Finding the most suitable text color out of a limited set of custom theme colors.
* Finding the most similar color out of a limited set of colors.