### PR TITLE
Unhide colorcheck command

### DIFF
--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -479,8 +479,7 @@ pub fn build_cli() -> Command<'static> {
         )
         .subcommand(
             Command::new("colorcheck")
-                .about("Check if your terminal emulator supports 24-bit colors.")
-                .hide(true),
+                .about("Check if your terminal emulator supports 24-bit colors."),
         )
         .arg(
             Arg::new("color-mode")


### PR DESCRIPTION
Closes #179

One-liner as discussed. Given there's already an `about` entry, didn't look like there was any other bookkeeping needed 🙂 