### PR TITLE
Fix lines in kitty terminal with text_fg_override_threshold set

### DIFF
--- a/src/cli/hdcanvas.rs
+++ b/src/cli/hdcanvas.rs
@@ -85,7 +85,7 @@ impl Canvas {
                     let p_bottom = self.pixel(2 * i_div_2 + 1, j);
 
                     match (p_top, p_bottom) {
-                        (Some(top), Some(bottom)) =>
+                        (Some(top), Some(bottom)) => {
                             if top == bottom {
                                 write!(
                                     out,
@@ -98,7 +98,8 @@ impl Canvas {
                                     "{}",
                                     self.brush.paint("▀", top.ansi_style().on(bottom))
                                 )?
-                            },
+                            }
+                        }
                         (Some(top), None) => write!(out, "{}", self.brush.paint("▀", top))?,
                         (None, Some(bottom)) => write!(out, "{}", self.brush.paint("▄", bottom))?,
                         (None, None) => write!(out, " ")?,

--- a/src/cli/hdcanvas.rs
+++ b/src/cli/hdcanvas.rs
@@ -75,6 +75,13 @@ impl Canvas {
         }
     }
 
+    // The kitty terminal has a feature text_fg_override_threshold that
+    // checks the difference in luminosity between text and background and
+    // changes the text to black or white to make it readable if the
+    // luminosity difference percentage is below the specified threshold.
+    // Using block characters for graphics display can trigger this, causing
+    // black or white lines or blocks, if the color is the same or too close.
+    // The checkerboard should be ok unless the theshold is set fairly high.
     pub fn print(&self, out: &mut dyn Write) -> Result<()> {
         for i_div_2 in 0..self.height / 2 {
             for j in 0..self.width {

--- a/src/cli/hdcanvas.rs
+++ b/src/cli/hdcanvas.rs
@@ -85,11 +85,20 @@ impl Canvas {
                     let p_bottom = self.pixel(2 * i_div_2 + 1, j);
 
                     match (p_top, p_bottom) {
-                        (Some(top), Some(bottom)) => write!(
-                            out,
-                            "{}",
-                            self.brush.paint("▀", top.ansi_style().on(bottom))
-                        )?,
+                        (Some(top), Some(bottom)) =>
+                            if top == bottom {
+                                write!(
+                                    out,
+                                    "{}",
+                                    self.brush.paint(" ", top.ansi_style().on(bottom))
+                                )?
+                            } else {
+                                write!(
+                                    out,
+                                    "{}",
+                                    self.brush.paint("▀", top.ansi_style().on(bottom))
+                                )?
+                            },
                         (Some(top), None) => write!(out, "{}", self.brush.paint("▀", top))?,
                         (None, Some(bottom)) => write!(out, "{}", self.brush.paint("▄", bottom))?,
                         (None, None) => write!(out, " ")?,


### PR DESCRIPTION
The kitty terminal has a new setting text_fg_override_threshold that checks the luminosity difference between the text and background and if it is above the set percentage turns the text black or white to get the best possible visibility.  pastel currently uses a unicode half block character and sets both forground and background to the same color in the color patch.  This patch changes this to be a space with both forground and background colors set to the same color (only becuase I don't know enough rust to figure out how to just set background color :/).

Possibly this could cause trouble with some background transparency settings, although if so the current situation might as well to a lesser extent.  I'm not sure how to make using text color work reliably with text_fg_override_threshold so I think a command line option to use one or the other would be needed there unless another drawing option is used.

There are two other ways to draw on kitty that could be considered.  The graphics protocol allow arbitrary images to be displayed and is supported by a few other terminals.  kitty also supports using colors with DECCARA, although I don't know if any other terminals support this.  In any case, with this patch it works for me and I checked that it still works on alacritty as well.