### PR TITLE
Fix CMYK from-conversion and add it as possible color function

### DIFF
--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -24,7 +24,8 @@ pub fn build_cli() -> Command<'static> {
              \n  - 789\
              \n  - 'rgb(119, 136, 153)'\
              \n  - '119,136,153'\
-             \n  - 'hsl(210, 14.3%, 53.3%)'\n\
+             \n  - 'hsl(210, 14.3%, 53.3%)'\
+             \n  - 'cmyk(22, 11, 0, 40)'\n\
              Alpha transparency is also supported:\
              \n  - '#77889980'\
              \n  - 'rgba(119, 136, 153, 0.5)'\

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -960,11 +960,11 @@ impl From<&LCh> for Color {
 impl From<&CMYK> for Color {
     fn from(color: &CMYK) -> Self {
         #![allow(clippy::many_single_char_names)]
-        let r = 255.0 * ((1.0 - color.c) / 100.0) * ((1.0 - color.k) / 100.0);
-        let g = 255.0 * ((1.0 - color.m) / 100.0) * ((1.0 - color.k) / 100.0);
-        let b = 255.0 * ((1.0 - color.y) / 100.0) * ((1.0 - color.k) / 100.0);
+        let r = Scalar::round(255.0 * (1.0 - color.c / 100.0) * (1.0 - color.k / 100.0)) as u8;
+        let g = Scalar::round(255.0 * (1.0 - color.m / 100.0) * (1.0 - color.k / 100.0)) as u8;
+        let b = Scalar::round(255.0 * (1.0 - color.y / 100.0) * (1.0 - color.k / 100.0)) as u8;
 
-        Color::from(&RGBA::<f64> {
+        Color::from(&RGBA::<u8> {
             r,
             g,
             b,
@@ -1429,13 +1429,7 @@ impl From<&Color> for CMYK {
         let r = (rgba.r as f64) / 255.0;
         let g = (rgba.g as f64) / 255.0;
         let b = (rgba.b as f64) / 255.0;
-        let biggest = if r >= g && r >= b {
-            r
-        } else if g >= r && g >= b {
-            g
-        } else {
-            b
-        };
+        let biggest = r.max(g).max(b);
         let out_k = 1.0 - biggest;
         let out_c = (1.0 - r - out_k) / biggest;
         let out_m = (1.0 - g - out_k) / biggest;


### PR DESCRIPTION
I stumbled across this project yesterday, and it's a really cool tool :)

I'm trying to create a colorscheme for my text editor base on some design book I own, in which all colors are specified using the CMYK format.
Using pastel to convert from CMYK to hex, so my editor would understand it, seemed like a no-brainer, but even though the `Self::from(CMYK)` function exists, it is never used anywhere in the project. 
Also, I've noticed the calculation were wrong in that function, so I fixed those and add the corresponding `parse_cmyk` function, so it can be used as a color value in commands.

This is my first time "writing" rust code, please feel free to report any mistake I've made :)
I would understand if this is rejected because it's too niche of a usage.