### PR TITLE
Added `alpha` property to `set` command

### DIFF
--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -359,7 +359,8 @@ pub fn build_cli() -> Command<'static> {
                                            "lab-a", "lab-b",
                                            "oklab-l", "oklab-a", "oklab-b",
                                            "red", "green", "blue",
-                                           "hsl-hue", "hsl-saturation", "hsl-lightness"])
+                                           "hsl-hue", "hsl-saturation", "hsl-lightness",
+                                           "alpha"])
                         .ignore_case(true)
                         .required(true),
                 )

--- a/src/cli/commands/color_commands.rs
+++ b/src/cli/commands/color_commands.rs
@@ -181,6 +181,11 @@ color_command!(SetCommand, config, matches, color, {
             }
             Color::from_lch(lch.l, lch.c, lch.h, lch.alpha)
         }
+        "alpha" => {
+            let mut hsla = color.to_hsla();
+            hsla.alpha = value;
+            Color::from_hsla(hsla.h, hsla.s, hsla.l, hsla.alpha)
+        }
         &_ => {
             unreachable!("Unknown property");
         }


### PR DESCRIPTION
Fixes #217

The `lib` already supported alpha, it just wasn't implemented into the CLI side of things as far as I can tell. I've added an argument to the `set` command, and added a match arm to handle `alpha`.

Here's some manual tests I've run to confirm it's functionality:

```sh
$ ./pastel color "lch(50,30,40)" | ./pastel set alpha 0.5 | ./pastel format lch
LCh(50, 30, 40, 0.5)

$ ./pastel color "hsl(134,50%,50%)" | ./pastel set alpha 0.5 | ./pastel format hsl
hsla(134, 50.0%, 50.0%, 0.5)

$ ./pastel color "hsla(253,40%,20%,0.2)" | ./pastel set alpha 0.6 | ./pastel format hsl
hsla(253, 40.0%, 20.0%, 0.6)

$ ./pastel color red | ./pastel set alpha 0.5 | ./pastel format
#ff000080
```

If you think either a) some testing, or b) a `transparent` color name would be nice, just let me know and I'll get that done.