### PR TITLE
fixed panic on list -s random

### DIFF
--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -11,7 +11,7 @@ impl GenericCommand for ListCommand {
         let sort_order = matches.value_of("sort-order").expect("required argument");
 
         let mut colors: Vec<&NamedColor> = NAMED_COLORS.iter().collect();
-        colors.sort_by_key(|nc| key_function(sort_order, &nc.color));
+        colors.sort_by_cached_key(|nc| key_function(sort_order, &nc.color));
         colors.dedup_by(|n1, n2| n1.color == n2.color);
 
         if config.interactive_mode {

--- a/src/cli/commands/sort.rs
+++ b/src/cli/commands/sort.rs
@@ -29,7 +29,7 @@ impl GenericCommand for SortCommand {
             colors.dedup_by_key(|c| c.to_u32());
         }
 
-        colors.sort_by_key(|c| key_function(sort_order, c));
+        colors.sort_by_cached_key(|c| key_function(sort_order, c));
 
         if matches.is_present("reverse") {
             colors.reverse();


### PR DESCRIPTION
fixed #234 by using `sort_by_cached_key()`, instead of `sort_by_key()`
`sort_by_cached_key()` calls key function only once, so this should fix the bug.