### PR TITLE
make option --force-color work while outputing to a shell pipe

### DIFF
--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -63,8 +63,9 @@ fn run() -> Result<ExitCode> {
     let global_matches = app.get_matches();
 
     let interactive_mode = atty::is(Stream::Stdout);
+    let force_color = global_matches.is_present("force-color");
 
-    let color_mode = if global_matches.is_present("force-color") {
+    let color_mode = if force_color {
         Some(ansi::Mode::TrueColor)
     } else {
         match global_matches
@@ -102,7 +103,7 @@ fn run() -> Result<ExitCode> {
         padding: 2,
         colorpicker_width: 48,
         colorcheck_width: 8,
-        interactive_mode,
+        interactive_mode: interactive_mode || force_color,
         brush: Brush::from_mode(color_mode),
         colorpicker: global_matches.value_of("color-picker"),
     };


### PR DESCRIPTION
### make option --force-color work while outputing to a shell pipe

Currently, when `pastel` is used to write to a shell pipe, it always outputs without colors.
This change makes it to respect the value of option `--force-color` when called in a shell pipe.

### Example usage

```sh
$ pastel --force-color list | column

```

#### Result

<img width="1233" height="1046" alt="pastel --force-color list | column" src="https://github.com/user-attachments/assets/5904467f-bf7c-4abc-acd0-d18083f2e92d" />
