### PR TITLE
Fix RGBA format in from_u32 documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,7 +348,7 @@ impl Color {
         u32::from(rgba.r).wrapping_shl(16) + u32::from(rgba.g).wrapping_shl(8) + u32::from(rgba.b)
     }
 
-    /// Parse the RGBA representation (`0xRRGGBBAA`) of an u32 into a Color.
+    /// Parse the RGBA representation (`0xAARRGGBB`) of an u32 into a Color.
     pub fn from_u32(n: u32) -> Color {
         let a = n >> 24;
         let r = (n >> 16) & 0xff;


### PR DESCRIPTION
The documentation says `0xRRGGBBAA` but the implementation is for `0xAARRGGBB`