### PR TITLE
Update version header format for 0.9.0 in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 - Suggest to use pastel pick --help instead of -h, see #181 (@sharkdp)
 
 
-## v0.9.0
+# v0.9.0
 
 ## Features
 


### PR DESCRIPTION
It should use `#` header as the other versions before and after it