### PR TITLE
Replace atty dependency with std::io::IsTerminal (breaking)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,17 +92,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,15 +327,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,7 +439,6 @@ version = "0.11.0"
 dependencies = [
  "approx",
  "assert_cmd",
- "atty",
  "clap",
  "clap_complete",
  "clap_mangen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ rust-version = "1.83.0"
 
 [dependencies]
 # library dependencies
-atty = "0.2"
 nom = "7.1.3"
 once_cell = "1.21.3"
 output_vt100 = "0.1"

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
+use std::io::IsTerminal;
 
-pub use atty::Stream;
 use once_cell::sync::Lazy;
 
 use crate::delta_e::ciede2000;
@@ -280,8 +280,8 @@ impl Brush {
         Brush { mode }
     }
 
-    pub fn from_environment(stream: Stream) -> Result<Self, UnknownColorModeError> {
-        let mode = if atty::is(stream) {
+    pub fn from_environment<T: IsTerminal>(stream: &T) -> Result<Self, UnknownColorModeError> {
+        let mode = if stream.is_terminal() {
             let env_color_mode = std::env::var("PASTEL_COLOR_MODE").ok();
             match env_color_mode.as_deref() {
                 Some(mode_str) => Mode::from_mode_str(mode_str)?,

--- a/src/cli/colorpicker.rs
+++ b/src/cli/colorpicker.rs
@@ -6,7 +6,7 @@ use crate::config::Config;
 use crate::error::{PastelError, Result};
 use crate::hdcanvas::Canvas;
 
-use pastel::ansi::{Brush, Stream};
+use pastel::ansi::Brush;
 use pastel::Color;
 
 /// Print a color spectrum to STDERR.
@@ -16,7 +16,7 @@ pub fn print_colorspectrum(config: &Config) -> Result<()> {
     let mut canvas = Canvas::new(
         width + 2 * config.padding,
         width + 2 * config.padding,
-        Brush::from_environment(Stream::Stderr)?,
+        Brush::from_environment(&io::stderr())?,
     );
     canvas.draw_rect(
         config.padding,

--- a/src/cli/commands/distinct.rs
+++ b/src/cli/commands/distinct.rs
@@ -2,7 +2,6 @@ use std::io::{self, Write};
 
 use crate::commands::prelude::*;
 
-use pastel::ansi::Stream;
 use pastel::distinct::{self, DistanceMetric, IterationStatistics};
 use pastel::{Fraction, HSLA};
 
@@ -129,7 +128,7 @@ impl GenericCommand for DistinctCommand {
     fn run(&self, out: &mut Output, matches: &ArgMatches, config: &Config) -> Result<()> {
         let stderr = io::stderr();
         let mut stderr_lock = stderr.lock();
-        let brush_stderr = Brush::from_environment(Stream::Stderr)?;
+        let brush_stderr = Brush::from_environment(&io::stderr())?;
         let verbose_output = matches.get_flag("verbose");
 
         let count = matches

--- a/src/cli/commands/io.rs
+++ b/src/cli/commands/io.rs
@@ -1,4 +1,4 @@
-use std::io::{self, BufRead};
+use std::io::{self, BufRead, IsTerminal};
 
 use clap::parser::ValuesRef;
 use clap::ArgMatches;
@@ -37,8 +37,7 @@ impl<'a> ColorArgIterator<'a> {
                 PrintSpectrum::Yes,
             )),
             None => {
-                use atty::Stream;
-                if atty::is(Stream::Stdin) {
+                if io::stdin().is_terminal() {
                     return Err(PastelError::ColorArgRequired);
                 }
                 Ok(ColorArgIterator::FromStdin)

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1,6 +1,4 @@
-use std::io::{self, Write};
-
-use atty::Stream;
+use std::io::{self, IsTerminal, Write};
 
 mod cli;
 mod colorpicker;
@@ -26,7 +24,7 @@ fn write_stderr(c: Color, title: &str, message: &str) {
     writeln!(
         io::stderr(),
         "{}: {}",
-        Brush::from_environment(Stream::Stdout)
+        Brush::from_environment(&io::stdout())
             .unwrap_or_default()
             .paint(format!("[{}]", title), c),
         message
@@ -62,7 +60,7 @@ fn run() -> Result<ExitCode> {
     let app = cli::build_cli();
     let global_matches = app.get_matches();
 
-    let interactive_mode = atty::is(Stream::Stdout);
+    let interactive_mode = io::stdout().is_terminal();
 
     let color_mode = if global_matches.get_flag("force-color") {
         Some(ansi::Mode::TrueColor)


### PR DESCRIPTION
Available since Rust 1.70: https://doc.rust-lang.org/std/io/trait.IsTerminal.html#tymethod.is_terminal

This change is useful because:

- it removes a now-unnecessary dependency
- the `atty` crate is unmaintained, https://rustsec.org/advisories/RUSTSEC-2024-0375.html
- the `atty` crate is potentially unsound on Windows, https://rustsec.org/advisories/RUSTSEC-2021-0145.html

On the other hand, `atty::Stream` appears in the public API, so this would be a breaking change.

I’m happy to revise the details based on feedback, or for you to take the general idea and reimplement it differently if you prefer.